### PR TITLE
Label dependabot PRs as `non-functional`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,21 +5,29 @@ updates:
     rebase-strategy: auto
     schedule:
       interval: daily
+    labels:
+      - non-functional
 
   - directory: /h5p-bildetema
     package-ecosystem: npm
     rebase-strategy: auto
     schedule:
       interval: daily
+    labels:
+      - non-functional
 
   - directory: /h5p-bildetema-topic-list
     package-ecosystem: npm
     rebase-strategy: auto
     schedule:
       interval: daily
+    labels:
+      - non-functional
 
   - directory: /
     package-ecosystem: github-actions
     rebase-strategy: auto
     schedule:
       interval: daily
+    labels:
+      - non-functional


### PR DESCRIPTION
We don't want them to create new releases anyways