### PR TITLE
use `columns` to place elements in two columns (first left, then right)

### DIFF
--- a/common/abstracts/_variables.scss
+++ b/common/abstracts/_variables.scss
@@ -27,8 +27,4 @@ $toggle-off-color: #ccc;
 $toggle-slider-color: white;
 $toggle-focus-color: black;
 
-$topic-card-big-width: 343px;
-$topic-card-big-height: 246px;
-
-$topic-card-compact-width: 464px;
-$topic-card-compact-height: 82px;
+$topic-card-big-width: 18.75rem;

--- a/h5p-bildetema/src/components/TopicGrid/TopicGrid.module.scss
+++ b/h5p-bildetema/src/components/TopicGrid/TopicGrid.module.scss
@@ -1,13 +1,9 @@
 @use "../../../../common/abstracts" as *;
 
-.gridBig,
-.gridCompact {
-  display: inline-grid;
-  grid-gap: $spacing--16;
-  width: 100%;
-}
-
 .gridBig {
+  display: grid;
+  grid-gap: $spacing--16;
+
   /* static elements */
   // grid-template-columns: repeat(auto-fill, $topic-card-big-width);
 
@@ -16,8 +12,9 @@
 }
 
 .gridCompact {
-  grid-template-columns: repeat(
-    auto-fit,
-    minmax($topic-card-compact-width, 1fr)
-  );
+  column-gap: $spacing--16;
+
+  @media screen and (min-width: 50rem) {
+    column-count: 2;
+  }
 }

--- a/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
+++ b/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
@@ -19,11 +19,6 @@
   }
 }
 
-.gridElementBig {
-  position: absolute;
-  bottom: 0;
-}
-
 .gridElementCompact {
   display: flex;
   flex-direction: column;
@@ -32,31 +27,33 @@
 
 .topicCardBig,
 .topicCardCompact {
-  display: flex;
-  margin: auto;
-  position: relative;
-  cursor: pointer;
   text-decoration: none;
+
+  &:hover > * {
+    background-color: $dark-beige;
+  }
 }
 
 .topicCardBig {
-  width: $topic-card-big-width;
-  height: $topic-card-big-height;
+  display: flex;
   flex-direction: column;
 }
 
 .topicCardCompact {
-  width: $topic-card-compact-width;
-  height: $topic-card-compact-height;
+  display: inline-flex;
   flex-direction: row;
-  vertical-align: middle;
-}
-
-.topicCardBig:hover > *,
-.topicCardCompact:hover > * {
-  background-color: $dark-beige;
+  margin-block-end: $spacing--16;
+  inline-size: 100%;
 }
 
 .topicImage {
-  object-fit: contain;
+  object-fit: cover;
+
+  .topicCardBig & {
+    aspect-ratio: 16 / 9;
+  }
+
+  .topicCardCompact & {
+    block-size: 4.375rem;
+  }
 }


### PR DESCRIPTION
This PR changes image size from `contain` to `cover`, to make topic images fill out the same area (I think this was what we discussed in a recent meeting).

The PR also changes how the list view works, by using CSS `columns` instead of Grid, as this is easier to manage for the human eye.

The third thing it does is to make the items a tiny bit more dynamic.