### PR TITLE
Customise h5p-bildetema library update message

### DIFF
--- a/.github/workflows/h5p_bildetema_check-library-version.yml
+++ b/.github/workflows/h5p_bildetema_check-library-version.yml
@@ -15,16 +15,22 @@ on:
 env:
   working-directory: "./h5p-bildetema"
 
-defaults:
-  run:
-    working-directory: "./h5p-bildetema"
-
 jobs:
   check-h5p-library-version:
     name: Check H5P if library version is updated
     runs-on: ubuntu-latest
     steps:
       - name: Check library version
-        uses: boyum/comment-h5p-library-version-action@v1 # https://github.com/boyum/comment-h5p-library-version-action
+        uses: boyum/comment-h5p-library-version-action@v2 # https://github.com/boyum/comment-h5p-library-version-action
         with:
           working-directory: ${{env.working-directory}}
+          project-id: h5p-bildetema
+          cancel-label: non-functional-h5p-bildetema
+          version-changed-message: |
+            :tada: `H5P.Bildetema`'s library version was updated from **%OLD_VERSION%** to **%NEW_VERSION%**.
+          version-not-changed-message: |
+            :warning: `H5P.Bildetema`'s library version was not updated.
+            Add the label `%CANCEL_LABEL%` if this PR does not require a change of version numbers.
+
+            **Current version:** %NEW_VERSION%
+            **Main version:** %OLD_VERSION%

--- a/.github/workflows/h5p_bildetema_check-library-version.yml
+++ b/.github/workflows/h5p_bildetema_check-library-version.yml
@@ -27,10 +27,10 @@ jobs:
           project-id: h5p-bildetema
           cancel-label: non-functional-h5p-bildetema
           version-changed-message: |
-            :tada: `H5P.Bildetema`'s library version was updated from **%OLD_VERSION%** to **%NEW_VERSION%**.
+            :tada: \`H5P.Bildetema\`'s library version was updated from **%OLD_VERSION%** to **%NEW_VERSION%**.
           version-not-changed-message: |
-            :warning: `H5P.Bildetema`'s library version was not updated.
-            Add the label `%CANCEL_LABEL%` if this PR does not require a change of version numbers.
+            :warning: \`H5P.Bildetema\`'s library version was not updated.
+            Add the label \`%CANCEL_LABEL%\` if this PR does not require a change of version numbers.
 
             **Current version:** %NEW_VERSION%
             **Main version:** %OLD_VERSION%

--- a/h5p-bildetema/README.md
+++ b/h5p-bildetema/README.md
@@ -1,6 +1,6 @@
 # h5p-bildetema
 
-Empty project.
+H5P Bildetema is an [H5P](https://h5p.org) content type that provides an environment for teaching and learning new languages.
 
 ## Building and running on localhost
 


### PR DESCRIPTION
This PR adds a custom message for the `h5p-bildetema` sub-project. This helps with two things:

- The custom messages makes it easier to guess which project was or wasn't updated
- The new `project-id` setting makes it possible for the action to edit the correct messages when new commits are added