### PR TITLE
Add text-align center to word label in grid

### DIFF
--- a/h5p-bildetema-words-grid-view/src/components/Word/Word.module.scss
+++ b/h5p-bildetema-words-grid-view/src/components/Word/Word.module.scss
@@ -15,6 +15,8 @@
 
 .word_label {
   font-size: $font-size-24;
+  line-height: normal;
+  text-align: center;
 }
 
 .img {


### PR DESCRIPTION
Based on case with "Gummistøvler" text alignment and line height.
<img width="380" alt="Skjermbilde 2022-06-23 kl  15 54 48" src="https://user-images.githubusercontent.com/35261194/175316487-aba8a952-9048-4323-8285-20cede1b3009.png">
 