### PR TITLE
Initialize semantics structure for theme image

### DIFF
--- a/common/types/Point.ts
+++ b/common/types/Point.ts
@@ -1,0 +1,4 @@
+export type Point = {
+  x: number;
+  y: number;
+};

--- a/common/types/ThemeImageHotspot.ts
+++ b/common/types/ThemeImageHotspot.ts
@@ -1,0 +1,6 @@
+import { Point } from "./Point";
+
+export type ThemeImageHotspot = {
+  points: Point;
+  wordId: `V${string}`;
+};

--- a/h5p-bildetema-words-theme-image/semantics.json
+++ b/h5p-bildetema-words-theme-image/semantics.json
@@ -1,7 +1,7 @@
 [
   {
     "label": "Image",
-    "name": "topicImage",
+    "name": "themeImage",
     "type": "image"
   },
   {

--- a/h5p-bildetema-words-theme-image/semantics.json
+++ b/h5p-bildetema-words-theme-image/semantics.json
@@ -1,5 +1,52 @@
 [
   {
+    "label": "Image",
+    "name": "topicImage",
+    "type": "image"
+  },
+  {
+    "label": "Hotspots",
+    "name": "hotspots",
+    "type": "list",
+    "entity": "Hotspot",
+    "widget": "none",
+    "field": {
+      "label": "Hotspot",
+      "name": "hotspot",
+      "type": "group",
+      "fields": [
+        {
+          "label": "Points",
+          "name": "points",
+          "type": "list",
+          "entity": "Point",
+          "field": {
+            "label": "Point",
+            "name": "point",
+            "type": "group",
+            "fields": [
+              {
+                "label": "X",
+                "name": "x",
+                "type": "number"
+              },
+              {
+                "label": "Y",
+                "name": "y",
+                "type": "number"
+              }
+            ]
+          }
+        },
+        {
+          "label": "Word id",
+          "name": "wordId",
+          "type": "text"
+        }
+      ]
+    }
+  },
+  {
     "name": "behaviour",
     "type": "group",
     "label": "Behavioral settings",

--- a/h5p-bildetema-words-theme-image/src/h5p/H5PWrapper.tsx
+++ b/h5p-bildetema-words-theme-image/src/h5p/H5PWrapper.tsx
@@ -1,12 +1,15 @@
-import type { IH5PContentType } from "h5p-types";
+import type { IH5PContentType, Image } from "h5p-types";
 import { H5PContentType } from "h5p-utils";
 import * as React from "react";
 import { createRoot } from "react-dom/client";
 import { ContentIdContext, H5PContext, L10nContext } from "use-h5p";
+import type { ThemeImageHotspot } from "../../../common/types/ThemeImageHotspot";
 import App from "../App";
-import { TranslationKey } from "../types/TranslationKey";
+import type { TranslationKey } from "../types/TranslationKey";
 
 type Params = {
+  themeImage: Image;
+  hotspots: Array<ThemeImageHotspot>;
   l10n: Record<TranslationKey, string>;
 };
 

--- a/h5p-bildetema-words-theme-image/src/semantics.ts
+++ b/h5p-bildetema-words-theme-image/src/semantics.ts
@@ -3,7 +3,7 @@ import type { H5PBehaviour, H5PField, H5PL10n } from "h5p-types";
 export const semantics: Readonly<Array<H5PField | H5PBehaviour | H5PL10n>> = [
   {
     label: "Image",
-    name: "topicImage",
+    name: "themeImage",
     type: "image",
   },
   {

--- a/h5p-bildetema-words-theme-image/src/semantics.ts
+++ b/h5p-bildetema-words-theme-image/src/semantics.ts
@@ -2,6 +2,53 @@ import type { H5PBehaviour, H5PField, H5PL10n } from "h5p-types";
 
 export const semantics: Readonly<Array<H5PField | H5PBehaviour | H5PL10n>> = [
   {
+    label: "Image",
+    name: "topicImage",
+    type: "image",
+  },
+  {
+    label: "Hotspots",
+    name: "hotspots",
+    type: "list",
+    entity: "Hotspot",
+    widget: "none",
+    field: {
+      label: "Hotspot",
+      name: "hotspot",
+      type: "group",
+      fields: [
+        {
+          label: "Points",
+          name: "points",
+          type: "list",
+          entity: "Point",
+          field: {
+            label: "Point",
+            name: "point",
+            type: "group",
+            fields: [
+              {
+                label: "X",
+                name: "x",
+                type: "number",
+              },
+              {
+                label: "Y",
+                name: "y",
+                type: "number",
+              },
+            ],
+          },
+        },
+        {
+          label: "Word id",
+          name: "wordId",
+          type: "text",
+        },
+      ],
+    },
+  },
+  {
     name: "behaviour",
     type: "group",
     label: "Behavioral settings",

--- a/h5p-bildetema-words-theme-image/tsconfig.json
+++ b/h5p-bildetema-words-theme-image/tsconfig.json
@@ -1,4 +1,10 @@
 {
   "extends": "../tsconfig.base.json",
-  "include": ["./src/**/*", "typings.d.ts", "vite.config.ts", ".storybook/**/*"]
+  "include": [
+    "./src/**/*",
+    "typings.d.ts",
+    "vite.config.ts",
+    ".storybook/**/*",
+    "../common/**/*"
+  ]
 }


### PR DESCRIPTION
This PR adds an initial semantics structure for `h5p-bildetema-words-theme-image`, which will be used in its editor widget.

It also populates the content type initializer's `Params` type with an equivalent type structure.

I'm not totally sold on the `hotspot` name, suggestions are welcome. Also, if there are fields that are missing, please shout.