### PR TITLE
do insignificant change to fix format issues

### DIFF
--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -2,14 +2,14 @@
  * {1} Add a non-breaking space to set the minimum height of the
  *     element to the line-height. This prevents layout shifting.
  */
-.Breadcrumbs {
+.breadcrumbs {
   font-size: 1.5rem;
   display: flex;
   flex-direction: row;
   align-items: center;
 
   &::after {
-    $nbsp: \00A0;
+    $nbsp: \00a0;
     content: "#{$nbsp}"; /* {1} */
   }
 }

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -22,7 +22,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   const breadcrumbs = useBreadcrumbs(routes);
 
   return !breadCrumbs ? (
-    <div className={styles.Breadcrumbs}>
+    <div className={styles.breadcrumbs}>
       {breadcrumbs.slice(1).map(({ breadcrumb, key }, index) =>
         index !== breadcrumbs.length - 2 ? (
           <span key={key}>


### PR DESCRIPTION
Prettier for some reason triggers on `Breadcrumbs.tsx`, even though there are no formatting issues there. Trying to fix it by touching the file.