### PR TITLE
Fix width of square svg topic images

### DIFF
--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 11,
+  "patchVersion": 12,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
@@ -4,14 +4,13 @@
   position: absolute;
   top: 0;
   left: 0;
-  width: 100%;
+  max-width: 100%;
   max-height: 100%;
   height: auto;
+  width: auto;
 
   &Vertical {
     height: 100%;
-    max-width: 100%;
-    width: auto;
   }
 }
 
@@ -46,14 +45,17 @@
   width: 80%;
 }
 
-.imageVertical {
-  height: 100%;
+.imageVertical,
+.imageHorizontal {
   max-width: 100%;
   width: auto;
+}
+
+.imageVertical {
+  height: 100%;
 }
 
 .imageHorizontal {
   height: auto;
   max-height: 100%;
-  width: 100%;
 }

--- a/h5p-bildetema-words-topic-image/src/library.ts
+++ b/h5p-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaTopicImageView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 11,
+  patchVersion: 12,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Since we have a max height set we need to make the width: "auto" instead of 100% to avoid images being stretched out