### PR TITLE
Fix correct underline for languages in header

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 33,
+  "patchVersion": 34,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.module.scss
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.module.scss
@@ -25,3 +25,9 @@
   max-width: $main-content-max-width;
   width: $main-content-width;
 }
+
+// Overrides for WordPress below
+a:hover,
+a:focus {
+  text-decoration-style: solid;
+}

--- a/h5p-bildetema/src/components/Header/Header.module.scss
+++ b/h5p-bildetema/src/components/Header/Header.module.scss
@@ -73,6 +73,7 @@
   border: none;
   cursor: pointer;
   font-size: $font-size-18;
+  text-decoration: none;
 }
 
 .languageButton {

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 33,
+  patchVersion: 34,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
In devdev, languages who are not the active language has an underline. Only the active language should have underline