### PR TITLE
Fix topic size buttons on mobile

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 35,
+  "patchVersion": 36,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Icons/Icons.tsx
+++ b/h5p-bildetema/src/components/Icons/Icons.tsx
@@ -60,7 +60,6 @@ export const BigTopicsIcon: React.FC<IconProps & IconSizeProps> = ({
     viewBox="0 0 32 32"
     fill="transparent"
     xmlns="http://www.w3.org/2000/svg"
-    style={{ verticalAlign: "middle", marginLeft: "-4px" }}
   >
     <path
       d="M12.8888 6.66699H7.70355C7.1308 6.66699 6.6665 7.13129 6.6665 7.70404V12.8893C6.6665 13.462 7.1308 13.9263 7.70355 13.9263H12.8888C13.4615 13.9263 13.9258 13.462 13.9258 12.8893V7.70404C13.9258 7.13129 13.4615 6.66699 12.8888 6.66699Z"
@@ -104,7 +103,6 @@ export const CompactTopicsIcon: React.FC<IconProps & IconSizeProps> = ({
     viewBox="0 0 32 32"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    style={{ verticalAlign: "middle", marginLeft: "-4px" }}
   >
     <path
       d="M5.33325 8H7.99992V10.6667H5.33325V8ZM5.33325 14.6667H7.99992V17.3333H5.33325V14.6667ZM5.33325 21.3333H7.99992V24H5.33325V21.3333ZM26.6666 10.6667V8H10.6973V10.6667H25.0666H26.6666ZM10.6666 14.6667H26.6666V17.3333H10.6666V14.6667ZM10.6666 21.3333H26.6666V24H10.6666V21.3333Z"

--- a/h5p-bildetema/src/components/TopicSizeButtons/TopicSizeButtons.module.scss
+++ b/h5p-bildetema/src/components/TopicSizeButtons/TopicSizeButtons.module.scss
@@ -8,12 +8,16 @@
 
 .buttonBig,
 .buttonCompact {
+  color: #000;
   cursor: pointer;
+  line-height: 50%;
   min-width: 2.5rem;
   max-width: 2.5rem;
   min-height: 2.5rem;
   max-height: 2.5rem;
   overflow: hidden;
+  padding: 0;
+  text-align: center;
   background-color: transparent;
   border-radius: 8px;
   border-color: transparent;

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 35,
+  patchVersion: 36,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
TopicSizeButtons appeared like this on mobile:
<img width="470" alt="Skjermbilde 2022-08-18 kl  16 20 28" src="https://user-images.githubusercontent.com/35261194/185422760-7ad74cf8-09c9-4b96-81a1-9833504ba9bd.png">

Trying to fix it with this pr