### PR TITLE
Use CSS to show/hide placeholder grid elements

### DIFF
--- a/h5p-bildetema/src/components/TopicGrid/TopicGrid.module.scss
+++ b/h5p-bildetema/src/components/TopicGrid/TopicGrid.module.scss
@@ -22,3 +22,11 @@
     column-count: 3;
   }
 }
+
+.placeholder {
+  display: none;
+
+  &:nth-child(-n + 4) {
+    display: block;
+  }
+}

--- a/h5p-bildetema/src/components/TopicGrid/TopicGrid.tsx
+++ b/h5p-bildetema/src/components/TopicGrid/TopicGrid.tsx
@@ -33,13 +33,6 @@ export const TopicGrid: React.FC<TopicGridProps> = ({
     setIsWordView(!!words);
   }, [words, setIsWordView]);
 
-  // Use placeholder(s) to make TopicGridElements the same size in Big grid
-  const usePlaceholders =
-    topicsSize === TopicGridSizes.Big && topics && topics?.length < 4;
-  const numberOfPlaceholders = usePlaceholders
-    ? 4 - Math.floor(topics?.length)
-    : 0;
-
   if (topics) {
     return (
       <div
@@ -65,11 +58,11 @@ export const TopicGrid: React.FC<TopicGridProps> = ({
             />
           );
         })}
-        {usePlaceholders &&
-          [...Array(numberOfPlaceholders)].map((_item, index) => {
-            // eslint-disable-next-line react/no-array-index-key
-            return <div key={`placeholder-${index}`} />;
-          })}
+
+        <div className={styles.placeholder} />
+        <div className={styles.placeholder} />
+        <div className={styles.placeholder} />
+        <div className={styles.placeholder} />
       </div>
     );
   }


### PR DESCRIPTION
Use whichever solution you prefer. With this, we end up always having the placeholders in the DOM, however we don't need to do the calculation in JS.