### PR TITLE
Fix language selector in Safari

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 61,
+  "patchVersion": 62,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Icons/Icons.tsx
+++ b/h5p-bildetema/src/components/Icons/Icons.tsx
@@ -120,12 +120,12 @@ export const LanguageMenuArrowIcon: React.FC<
     viewBox="0 0 16 10"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
-    transform={transform}
-    transform-origin={transformOrigin}
   >
     <path
       d="M8 9.49974L0 1.49974L1.43333 0.0664062L8 6.66641L14.5667 0.0997391L16 1.53307L8 9.49974Z"
       fill="white"
+      transform={transform}
+      transform-origin={transformOrigin}
     />
   </svg>
 );

--- a/h5p-bildetema/src/components/LanguageDropdown/LanguageDropdown.module.scss
+++ b/h5p-bildetema/src/components/LanguageDropdown/LanguageDropdown.module.scss
@@ -5,6 +5,7 @@
   gap: $spacing--8;
   flex-direction: column;
   align-items: flex-end;
+  position: relative;
 
   @media print {
     display: none;

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
@@ -49,6 +49,10 @@
   height: 100%;
   align-items: center;
 
+  @include breakpoint-min($small) {
+    width: max-content;
+  }
+
   &:hover {
     text-decoration-line: underline;
   }

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 61,
+  patchVersion: 62,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
- Move transform attributes from svg to path, since svg is not allowed to have transform attributes in SVG 1.1 and Safari does not support it for SVG 2 either
- Make sure languageDropdown has relative position, was not positioning correctly in Safari