### PR TITLE
Fix home icon css

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 62,
+  "patchVersion": 63,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
+++ b/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
@@ -10,6 +10,8 @@
 .wrapper {
   position: relative;
   display: inline-block;
+  height: 1.2em;
+  width: 1.2em;
 
   /* Hide default HTML checkbox */
   & input {

--- a/h5p-bildetema/src/components/Icons/Icons.tsx
+++ b/h5p-bildetema/src/components/Icons/Icons.tsx
@@ -26,7 +26,7 @@ export const HomeIcon: React.FC<IconProps & IconSizeProps> = ({
     viewBox="0 0 24 24"
     width="24px"
     fill="currentcolor"
-    transform="scale(1.5)"
+    style={{ transform: "scale(1.5)" }}
   >
     <path d="M0 0h24v24H0V0z" fill="none" />
     <path

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
@@ -48,6 +48,7 @@
   gap: $spacing--16;
   height: 100%;
   align-items: center;
+  line-height: 1;
 
   @include breakpoint-min($small) {
     width: max-content;

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 62,
+  patchVersion: 63,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
and small fixes in language selector
- Centering star-icons with previously used height and width
- Setting a line-height for when language text is on two lines