### PR TITLE
Preserve aspect ratio of svg overlay in Safari/iOS

### DIFF
--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 26,
+  "patchVersion": 27,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.tsx
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.tsx
@@ -50,7 +50,7 @@ export const TopicImageSVG: React.FC<TopicImageSVGProps> = ({
         className={`${styles.overlays} ${
           isVertical ? styles.overlaysVertical : ""
         }`}
-        preserveAspectRatio="none"
+        preserveAspectRatio="xMinYMin"
         viewBox={`0 0 100 ${100 / aspectRatio}`}
       >
         {overlayFields}

--- a/h5p-bildetema-words-topic-image/src/library.ts
+++ b/h5p-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaTopicImageView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 26,
+  patchVersion: 27,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Make sure aspect ratio is preserved and align the svg overlay to the top left corner