### PR TITLE
Fix show words in Safari

### DIFF
--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 28,
+  "patchVersion": 29,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/src/components/TopicWordsGrid/TopicWordsGrid.tsx
+++ b/h5p-bildetema-words-grid-view/src/components/TopicWordsGrid/TopicWordsGrid.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { useContentId } from "use-h5p";
 import { Word as WordType } from "../../../../common/types/types";
 import { Word } from "../Word/Word";
 import styles from "./TopicWordsGrid.module.scss";
@@ -13,34 +12,10 @@ export const TopicWordsGrid: React.FC<TopicWordsGridProps> = ({
   words,
   showWrittenWords,
 }) => {
-  const [textVisible, setTextVisible] = React.useState(showWrittenWords);
-
-  const handleChange = (e: Event): void => {
-    setTextVisible((e.target as HTMLInputElement).checked);
-  };
-
-  const contentId = useContentId();
-
-  React.useEffect(() => {
-    // Hack: Navigating from topic -> words causes document.getElementById(`toggle-${contentId}`) to be null, if we not wait for one whole frame...
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        document
-          .getElementById(`toggle-${contentId}`)
-          ?.addEventListener("change", handleChange);
-      });
-    });
-    return () => {
-      document
-        .getElementById(`toggle-${contentId}`)
-        ?.removeEventListener("change", handleChange);
-    };
-  }, [contentId]);
-
   return (
     <div className={styles.topicgrid}>
       {words.map(word => (
-        <Word key={word.id} word={word} textVisible={textVisible} />
+        <Word key={word.id} word={word} textVisible={showWrittenWords} />
       ))}
     </div>
   );

--- a/h5p-bildetema-words-grid-view/src/library.ts
+++ b/h5p-bildetema-words-grid-view/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaWordsGridView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 28,
+  patchVersion: 29,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
When starting at any other page than the grid image page and navigation to a grid image page, the show words toggle will not work. Seems like we don't need the hack created for show words, since the showWrittenWords value is always correct (when I have tested at least).