### PR TITLE
Make star focusable

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 66,
+  "patchVersion": 67,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
+++ b/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
@@ -15,6 +15,9 @@
 
   /* Hide default HTML checkbox */
   & input {
-    @include visually-hidden;
+    all: unset;
+    position: absolute;
+    height: 1.2em;
+    width: 1.2em;
   }
 }

--- a/h5p-bildetema/src/components/Checkbox/Checkbox.tsx
+++ b/h5p-bildetema/src/components/Checkbox/Checkbox.tsx
@@ -15,6 +15,12 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   checked,
   disabled,
 }) => {
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+    if (e.key === "Enter") {
+      handleChange(!!checked);
+    }
+  };
+
   return (
     <label className={styles.container} htmlFor={id}>
       <span className={styles.wrapper}>
@@ -23,6 +29,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           type="checkbox"
           checked={checked}
           onChange={e => handleChange(e.target.checked)}
+          onKeyDown={e => handleKeyDown(e)}
           disabled={disabled}
         />
         {checked ? <StarFilledIcon /> : <StarOutlineIcon />}

--- a/h5p-bildetema/src/components/Checkbox/Checkbox.tsx
+++ b/h5p-bildetema/src/components/Checkbox/Checkbox.tsx
@@ -15,12 +15,6 @@ export const Checkbox: React.FC<CheckboxProps> = ({
   checked,
   disabled,
 }) => {
-  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-    if (e.key === "Enter") {
-      handleChange(!!checked);
-    }
-  };
-
   return (
     <label className={styles.container} htmlFor={id}>
       <span className={styles.wrapper}>
@@ -29,7 +23,6 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           type="checkbox"
           checked={checked}
           onChange={e => handleChange(e.target.checked)}
-          onKeyDown={e => handleKeyDown(e)}
           disabled={disabled}
         />
         {checked ? <StarFilledIcon /> : <StarOutlineIcon />}

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 66,
+  patchVersion: 67,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Focus does not work on elements that are hidden. Make the checkbox hidden for the eye only by unsetting styling, and keep other functionalities.