### PR TITLE
Add 1px padding to Images 

### DIFF
--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 33,
+  "patchVersion": 34,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/src/components/Image/Image.module.scss
+++ b/h5p-bildetema-words-grid-view/src/components/Image/Image.module.scss
@@ -1,4 +1,6 @@
 .img {
+  box-sizing: border-box;
+  padding: 1px;
   object-fit: contain;
   object-position: bottom center;
   width: 100%;

--- a/h5p-bildetema-words-grid-view/src/library.ts
+++ b/h5p-bildetema-words-grid-view/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaWordsGridView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 33,
+  patchVersion: 34,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Add 1px padding to swiper images to fix issue where pixels from the next image are visible
![image](https://user-images.githubusercontent.com/71496242/192790939-7424b923-94ad-494e-ae53-b4c5d72298ae.png)
