### PR TITLE
Fix breadcrumbs for 768 width devices

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 100,
+  "patchVersion": 101,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -36,13 +36,20 @@
 }
 
 .wrapperHide {
-  @include breakpoint-max($small) {
-    display: none;
+  display: none;
+
+  @include breakpoint-min($small) {
+    display: flex;
   }
 }
 
 .link {
   all: unset;
+  align-items: center;
+  display: flex;
+  font-size: $font-size-18;
+  gap: 0.5rem;
+  height: 1.5rem;
   text-decoration: none;
   cursor: pointer;
 
@@ -51,19 +58,12 @@
     text-decoration: none;
   }
 
-  @include breakpoint-max($small) {
-    align-items: center;
-    display: flex;
-    font-size: $font-size-18;
-    gap: 0.5rem;
-    height: 1.5rem;
-  }
-
   @include breakpoint-min($small) {
     background-color: $grey;
     border: 2px solid transparent;
     border-radius: 1rem;
     font-size: $font-size-18;
+    height: auto;
     padding: 0.375rem 1rem;
 
     &:hover {
@@ -119,11 +119,12 @@
   }
 
   .backIcon {
+    display: none;
     height: 1.5rem;
     width: 1.5rem;
 
-    @include breakpoint-max($small) {
-      display: none;
+    @include breakpoint-min($small) {
+      display: block;
     }
   }
 }

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 100,
+  patchVersion: 101,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Since both breakpoint-min and breakpoint-max was used, devices with a width of 768 came in between these sizes and got a different appearance