### PR TITLE
Make site more accessible

### DIFF
--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 47,
+  "patchVersion": 48,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/src/components/TopicWordsGrid/TopicWordsGrid.module.scss
+++ b/h5p-bildetema-words-grid-view/src/components/TopicWordsGrid/TopicWordsGrid.module.scss
@@ -9,14 +9,18 @@ $gap: $spacing--24;
   flex-direction: row;
   flex-wrap: wrap;
   gap: $gap;
+  margin: 0;
+  padding: 0;
   width: 100%;
 
   [class*="rtl"] & {
     justify-content: flex-end;
   }
 
-  & > div {
+  & > li {
     box-sizing: border-box;
+    list-style-type: none;
+    margin: 0;
     width: 100%;
 
     @include breakpoint-min(700px) {

--- a/h5p-bildetema-words-grid-view/src/components/TopicWordsGrid/TopicWordsGrid.tsx
+++ b/h5p-bildetema-words-grid-view/src/components/TopicWordsGrid/TopicWordsGrid.tsx
@@ -13,10 +13,11 @@ export const TopicWordsGrid: React.FC<TopicWordsGridProps> = ({
   showWrittenWords,
 }) => {
   return (
-    <div className={styles.topicgrid}>
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles
+    <ul role="list" className={styles.topicgrid}>
       {words.map(word => (
         <Word key={word.id} word={word} textVisible={showWrittenWords} />
       ))}
-    </div>
+    </ul>
   );
 };

--- a/h5p-bildetema-words-grid-view/src/components/Word/Word.tsx
+++ b/h5p-bildetema-words-grid-view/src/components/Word/Word.tsx
@@ -86,7 +86,6 @@ export const Word: React.FC<WordProps> = ({ textVisible, word }) => {
             type="button"
             className="swiper-button-next"
             aria-labelledby="next-button"
-            lang="en"
           >
             <span id="next-button" className={styles.visuallyHidden}>
               {nextLabel}

--- a/h5p-bildetema-words-grid-view/src/components/Word/Word.tsx
+++ b/h5p-bildetema-words-grid-view/src/components/Word/Word.tsx
@@ -44,8 +44,15 @@ export const Word: React.FC<WordProps> = ({ textVisible, word }) => {
         spaceBetween={10}
       >
         {numberOfImages > 1 && (
-          <button type="button" className="swiper-button-prev">
-            <span className={styles.visuallyHidden}>{prevLabel}</span>
+          // make sure our ARIA text is used instead of swiper's
+          <button
+            type="button"
+            className="swiper-button-prev"
+            aria-labelledby="prev-button"
+          >
+            <span id="prev-button" className={styles.visuallyHidden}>
+              {prevLabel}
+            </span>
           </button>
         )}
         {numberOfImages !== 0 ? (
@@ -74,8 +81,16 @@ export const Word: React.FC<WordProps> = ({ textVisible, word }) => {
           </SwiperSlide>
         )}
         {numberOfImages > 1 && (
-          <button type="button" className="swiper-button-next">
-            <span className={styles.visuallyHidden}>{nextLabel}</span>
+          // make sure our ARIA text is used instead of swiper's
+          <button
+            type="button"
+            className="swiper-button-next"
+            aria-labelledby="next-button"
+            lang="en"
+          >
+            <span id="next-button" className={styles.visuallyHidden}>
+              {nextLabel}
+            </span>
           </button>
         )}
       </Swiper>
@@ -85,9 +100,10 @@ export const Word: React.FC<WordProps> = ({ textVisible, word }) => {
   const hasAudio = word.audioFiles && word.audioFiles.length > 0;
 
   return (
-    <div className={styles.word}>
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles
+    <li role="listitem" className={styles.word}>
       <div className={styles.image_container}>{renderImages()}</div>
       {hasAudio && <WordAudio word={word} textVisible={textVisible} />}
-    </div>
+    </li>
   );
 };

--- a/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.module.scss
+++ b/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.module.scss
@@ -30,7 +30,9 @@
 
 .word_label {
   font-size: $font-size-24;
+  font-weight: normal;
   line-height: 1.4;
+  margin: 0;
   text-align: center;
   word-break: break-word;
 }

--- a/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.tsx
+++ b/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.tsx
@@ -58,10 +58,10 @@ export const WordAudio: React.FC<WordAudioProps> = ({ word, textVisible }) => {
       </audio>
       <button type="button" onClick={toggleAudio}>
         {textVisible && (
-          <span className={styles.word_label}>
+          <h2 className={styles.word_label}>
             {label}
             &nbsp;
-          </span>
+          </h2>
         )}
         <span className={styles.audioIconSpan}>
           <SpeakerIcon

--- a/h5p-bildetema-words-grid-view/src/library.ts
+++ b/h5p-bildetema-words-grid-view/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaWordsGridView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 47,
+  patchVersion: 48,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 114,
+  "patchVersion": 115,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -190,6 +190,7 @@ export const Bildetema: React.FC<BildetemaProps> = ({
         <div
           id="bildetemaMain"
           className={`${styles.body} ${directionRtl ? styles.rtl : ""}`}
+          aria-label="Main content" // TODO: translate
         >
           {isLoadingData ? showLoadingLabel && <p>{loadingLabel}</p> : routes}
         </div>

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -10,6 +10,8 @@
   flex-direction: column;
   font-size: 1.5rem;
   gap: $spacing--24;
+  margin: 0;
+  padding: 0;
 
   @include breakpoint-min($small) {
     align-items: center;
@@ -20,6 +22,11 @@
       $nbsp: \00a0;
       content: "#{$nbsp}"; /* {1} */
     }
+  }
+
+  li {
+    list-style-type: none;
+    margin: 0;
   }
 
   span {
@@ -55,6 +62,7 @@
   font-size: $font-size-18;
   gap: 0.5rem;
   height: 1.5rem;
+  line-height: 1;
   text-decoration: none;
   cursor: pointer;
 

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -28,7 +28,7 @@ describe(Breadcrumbs.name, () => {
     });
 
     expect(container.textContent).toEqual(",");
-    expect(container.querySelector("div")).toBeFalsy();
+    expect(container.querySelector("ol")).toBeTruthy();
     expect(container.querySelector("a")).toBeFalsy();
     expect(container.querySelector("span")).toBeFalsy();
   });

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -28,7 +28,7 @@ describe(Breadcrumbs.name, () => {
     });
 
     expect(container.textContent).toEqual(",");
-    expect(container.querySelector("div")).toBeTruthy();
+    expect(container.querySelector("div")).toBeFalsy();
     expect(container.querySelector("a")).toBeFalsy();
     expect(container.querySelector("span")).toBeFalsy();
   });

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -47,52 +47,71 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
       };
     });
 
-  return (
-    <div className={styles.breadcrumbs}>
-      {breadCrumbsToRender.map(({ label, path }, index) => {
-        const notLastBreadCrumb = index !== breadCrumbsToRender.length - 1;
-        const homePageBreadCrumb = index === 0;
-        const moreThanThreeItems = breadCrumbsToRender.length > 2;
+  const AriaBreadcrumbsNav = "breadcrumbs"; // TODO: translate
+  const onlyHomePage = breadCrumbsToRender && breadCrumbsToRender.length === 1;
 
-        return notLastBreadCrumb ? (
-          <span
-            key={path}
-            className={
-              homePageBreadCrumb && moreThanThreeItems
-                ? styles.wrapperHide
-                : styles.wrapper
-            }
-          >
-            <Link to={path} className={styles.link}>
-              <span className={styles.arrowLeft}>
-                <BreadcrumbsArrowLeftIcon />
+  if (onlyHomePage) {
+    const homePageElement = breadCrumbsToRender[0];
+
+    return (
+      <div className={styles.breadcrumbs}>
+        <h1 className={styles.currentPage} key={homePageElement.path}>
+          {homePageElement.label}
+        </h1>
+      </div>
+    );
+  }
+
+  return (
+    <nav aria-label={AriaBreadcrumbsNav}>
+      <ol className={styles.breadcrumbs}>
+        {breadCrumbsToRender.map(({ label, path }, index) => {
+          const notLastBreadCrumb = index !== breadCrumbsToRender.length - 1;
+          const homePageBreadCrumb = index === 0;
+          const moreThanThreeItems = breadCrumbsToRender.length > 2;
+
+          return notLastBreadCrumb ? (
+            <li
+              key={path}
+              className={
+                homePageBreadCrumb && moreThanThreeItems
+                  ? styles.wrapperHide
+                  : styles.wrapper
+              }
+            >
+              <Link to={path} className={styles.link}>
+                <span className={styles.arrowLeft} aria-hidden="true">
+                  <BreadcrumbsArrowLeftIcon />
+                </span>
+                {homePageBreadCrumb ? (
+                  <span className={styles.homeButton}>
+                    <span className={styles.homeIcon}>
+                      <HomeIcon />
+                    </span>
+                    <span className={styles.visuallyHidden}>{homeLabel}</span>
+                  </span>
+                ) : (
+                  <span className={styles.backButton}>
+                    <span className={styles.backIcon} aria-hidden="true">
+                      <BackIcon />
+                    </span>
+                    {label}
+                  </span>
+                )}
+              </Link>
+              <span className={styles.arrow} aria-hidden="true">
+                <BreadcrumbsArrowIcon />
               </span>
-              {homePageBreadCrumb ? (
-                <span className={styles.homeButton}>
-                  <span className={styles.homeIcon}>
-                    <HomeIcon />
-                  </span>
-                  <span className={styles.visuallyHidden}>{homeLabel}</span>
-                </span>
-              ) : (
-                <span className={styles.backButton}>
-                  <span className={styles.backIcon}>
-                    <BackIcon />
-                  </span>
-                  {label}
-                </span>
-              )}
-            </Link>
-            <span className={styles.arrow}>
-              <BreadcrumbsArrowIcon />
-            </span>
-          </span>
-        ) : (
-          <h1 className={styles.currentPage} key={path}>
-            {label}
-          </h1>
-        );
-      })}
-    </div>
+            </li>
+          ) : (
+            <li aria-current="page">
+              <h1 className={styles.currentPage} key={path}>
+                {label}
+              </h1>
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
   );
 };

--- a/h5p-bildetema/src/components/Header/Header.module.scss
+++ b/h5p-bildetema/src/components/Header/Header.module.scss
@@ -128,6 +128,7 @@
   display: none;
   gap: $spacing--8;
   flex-wrap: wrap;
+  margin: 0;
 
   @include breakpoint-min($medium) {
     display: flex;
@@ -135,6 +136,11 @@
 
   @media print {
     display: flex;
+  }
+
+  li {
+    list-style-type: none;
+    margin: 0;
   }
 }
 
@@ -144,6 +150,7 @@
   color: white;
   cursor: pointer;
   font-size: $font-size-18;
+  line-height: 1;
   margin: 0.35rem 0.5rem 0.25rem;
   padding: 0;
   text-decoration: none;

--- a/h5p-bildetema/src/components/Header/Header.tsx
+++ b/h5p-bildetema/src/components/Header/Header.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-redundant-roles */
 import React, {
   useEffect,
   useState,
@@ -44,6 +45,7 @@ export const Header: React.FC<HeaderProps> = ({
     "headerSubtitle",
     ...languageKeys,
   );
+  const navAriaLabel = "Favorite languages"; // TODO: translate
 
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const [langSelectorIsShown, setLangSelectorIsShown] = useState(false);
@@ -113,23 +115,32 @@ export const Header: React.FC<HeaderProps> = ({
           <span className={styles.logo_labels_subtitle}>{subTitleLabel}</span>
         </Link>
         <div className={styles.language_container}>
-          <div className={styles.languages}>
-            {favLanguages.map(language => {
-              return (
-                <Link
-                  key={language.code}
-                  to={getLanguagePath(language, topicIds, search, topicsFromDB)}
-                  className={`${styles.languageButton} ${
-                    currentLanguageCode === language.code
-                      ? styles.languageButton_active
-                      : ""
-                  }`}
-                >
-                  {langs[`lang_${language.code}`]}
-                </Link>
-              );
-            })}
-          </div>
+          <nav aria-label={navAriaLabel}>
+            <ul role="list" className={styles.languages}>
+              {favLanguages.map(language => {
+                return (
+                  <li role="listitem">
+                    <Link
+                      key={language.code}
+                      to={getLanguagePath(
+                        language,
+                        topicIds,
+                        search,
+                        topicsFromDB,
+                      )}
+                      className={`${styles.languageButton} ${
+                        currentLanguageCode === language.code
+                          ? styles.languageButton_active
+                          : ""
+                      }`}
+                    >
+                      {langs[`lang_${language.code}`]}
+                    </Link>
+                  </li>
+                );
+              })}
+            </ul>
+          </nav>
           <LanguageDropdown
             handleSelectorVisibility={setLangSelectorIsShown}
             langSelectorIsShown={langSelectorIsShown}

--- a/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.module.scss
+++ b/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.module.scss
@@ -48,6 +48,7 @@
   gap: $spacing--8;
   flex-wrap: nowrap;
   width: max-content;
+  margin: 0;
   padding: 0 $spacing--16;
 
   @media print {
@@ -57,6 +58,11 @@
     max-width: $main-content-max-width;
     width: $main-content-width;
   }
+
+  li {
+    list-style-type: none;
+    margin: 0;
+  }
 }
 
 .languageButton {
@@ -65,6 +71,7 @@
   color: white;
   cursor: pointer;
   font-size: $font-size-16;
+  line-height: 1;
   margin: 0.35rem 0.5rem 0.25rem;
   padding: 0;
   text-decoration: none;

--- a/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
+++ b/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-redundant-roles */
 import React from "react";
 import { Link, useLocation } from "react-router-dom";
 import { languages } from "../../../../common/constants/languages";
@@ -31,25 +32,29 @@ export const LanguageFavorites: React.FC<LanguageFavoritesProps> = ({
       ? (pathname.split("/")[1] as LanguageCode)
       : "nob";
 
+  const navAriaLabel = "Favorite languages"; // TODO: translate
+
   return (
-    <div className={styles.languageWrapper}>
-      <div className={styles.languages}>
+    <nav aria-label={navAriaLabel} className={styles.languageWrapper}>
+      <ul role="list" className={styles.languages}>
         {favLanguages.map(language => {
           return (
-            <Link
-              key={language.code}
-              to={getLanguagePath(language, topicIds, search, topicsFromDB)}
-              className={`${styles.languageButton} ${
-                currentLanguageCode === language.code
-                  ? styles.languageButton_active
-                  : ""
-              }`}
-            >
-              {langs[`lang_${language.code}`]}
-            </Link>
+            <li role="listitem">
+              <Link
+                key={language.code}
+                to={getLanguagePath(language, topicIds, search, topicsFromDB)}
+                className={`${styles.languageButton} ${
+                  currentLanguageCode === language.code
+                    ? styles.languageButton_active
+                    : ""
+                }`}
+              >
+                {langs[`lang_${language.code}`]}
+              </Link>
+            </li>
           );
         })}
-      </div>
-    </div>
+      </ul>
+    </nav>
   );
 };

--- a/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.module.scss
+++ b/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.module.scss
@@ -3,6 +3,8 @@
 .languageSelector {
   column-count: 1;
   display: block;
+  margin: 0;
+  padding: 0;
 
   @include breakpoint-min($medium) {
     column-count: 2;

--- a/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-redundant-roles */
 import React from "react";
 import styles from "./LanguageSelector.module.scss";
 import { Language, TopicIds } from "../../../../common/types/types";
@@ -26,9 +27,11 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
     return Math.max(1, Math.ceil(languages ? languages.length / 2 : 0));
   };
 
+  const navAriaLabel = "Choose language"; // TODO: translate
+
   return (
-    <div className={styles.languageSelectorWrapper}>
-      <div className={styles.languageSelector}>
+    <nav aria-label={navAriaLabel} className={styles.languageSelectorWrapper}>
+      <ul role="list" className={styles.languageSelector}>
         {languages?.map((language, index) => (
           <LanguageSelectorElement
             path={getLanguagePath(language, topicIds, search, topicsFromDB)}
@@ -40,7 +43,7 @@ export const LanguageSelector: React.FC<LanguageSelectorProps> = ({
             currentLanguageCode={currentLanguageCode}
           />
         ))}
-      </div>
-    </div>
+      </ul>
+    </nav>
   );
 };

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
@@ -6,6 +6,8 @@
   justify-content: flex-start;
   align-items: center;
   border-bottom: 1px solid lightgrey;
+  list-style-type: none;
+  margin: 0;
   transition-duration: 0.2s;
   width: 100%;
 

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.tsx
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.tsx
@@ -48,7 +48,9 @@ export const LanguageSelectorElement: React.FC<LanguageSelectorElement> = ({
   };
 
   return (
-    <div
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles
+    <li
+      role="listitem"
       className={`${middleElement ? styles.languageMiddle : styles.language} ${
         isDisabled ? styles.disabled : ""
       }`}
@@ -71,6 +73,6 @@ export const LanguageSelectorElement: React.FC<LanguageSelectorElement> = ({
         <span>{translations[`lang_${language.code}`]}</span>
         <span>{languagesOriginal[language.code]}</span>
       </Link>
-    </div>
+    </li>
   );
 };

--- a/h5p-bildetema/src/components/TopicGrid/TopicGrid.module.scss
+++ b/h5p-bildetema/src/components/TopicGrid/TopicGrid.module.scss
@@ -9,19 +9,23 @@ $gap: $spacing--24;
   flex-direction: row;
   flex-wrap: wrap;
   gap: $gap;
+  margin: 0;
+  padding: 0;
 
   [class*="rtl"] & {
     justify-content: flex-end;
   }
 
-  & > a {
+  & > li {
     box-sizing: border-box;
+    list-style-type: none;
+    margin: 0;
     width: 100%;
   }
 }
 
 .gridBig {
-  & > a {
+  & > li {
     @include breakpoint-min(650px) {
       width: calc((100% - #{$gap}) / 2);
     }
@@ -37,7 +41,7 @@ $gap: $spacing--24;
 }
 
 .gridCompact {
-  & > a {
+  & > li {
     @include breakpoint-min(800px) {
       width: calc((100% - #{$gap}) / 2);
     }

--- a/h5p-bildetema/src/components/TopicGrid/TopicGrid.tsx
+++ b/h5p-bildetema/src/components/TopicGrid/TopicGrid.tsx
@@ -39,7 +39,9 @@ export const TopicGrid: React.FC<TopicGridProps> = ({
 
   if (topics) {
     return (
-      <div
+      // eslint-disable-next-line jsx-a11y/no-redundant-roles
+      <ul
+        role="list"
         className={`${
           topicsSize === TopicGridSizes.Big
             ? styles.gridBig
@@ -61,7 +63,7 @@ export const TopicGrid: React.FC<TopicGridProps> = ({
             />
           );
         })}
-      </div>
+      </ul>
     );
   }
 

--- a/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
+++ b/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
@@ -28,6 +28,13 @@
   [class*="rtl"] & {
     direction: rtl;
   }
+
+  h2 {
+    font-size: inherit;
+    font-weight: inherit;
+    line-height: inherit;
+    margin: 0;
+  }
 }
 
 .gridElementBig {

--- a/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
+++ b/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
@@ -48,6 +48,10 @@
 .topicCardBig,
 .topicCardCompact {
   background-color: $beige;
+  border: 1.5px solid $dark-beige;
+  box-sizing: border-box;
+  display: flex;
+  height: 100%;
   text-decoration: none;
 
   &:hover {
@@ -57,20 +61,12 @@
 }
 
 .topicCardBig {
-  display: flex;
   flex-direction: column;
 }
 
 .topicCardCompact {
-  display: inline-flex;
   flex-direction: row;
-  inline-size: 100%;
   word-break: break-word;
-}
-
-.topicCardBig,
-.topicCardCompact {
-  border: 1.5px solid $dark-beige;
 }
 
 .topicImage {

--- a/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.tsx
+++ b/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.tsx
@@ -41,12 +41,19 @@ export const TopicGridElement: React.FC<TopicGridElementProps> = ({
     "https://images.unsplash.com/photo-1564349683136-77e08dba1ef7?ixlib=rb-1.2.1&w=640&q=80&fm=jpg&crop=entropy&cs=tinysrgb";
   const { search } = useLocation();
   return (
-    <Link className={topicCardClassName} to={`${linkTo}${search}`}>
-      <img className={styles.topicImage} src={imageSrc} alt="" />
-      <span className={gridElementClassName}>
-        {title}
-        <TopicGridElementAudio audioFiles={audioFiles} />
-      </span>
-    </Link>
+    // eslint-disable-next-line jsx-a11y/no-redundant-roles
+    <li role="listitem">
+      <Link
+        className={topicCardClassName}
+        to={`${linkTo}${search}`}
+        aria-label={title}
+      >
+        <img className={styles.topicImage} src={imageSrc} alt="" />
+        <span className={gridElementClassName}>
+          <h2>{title}</h2>
+          <TopicGridElementAudio audioFiles={audioFiles} />
+        </span>
+      </Link>
+    </li>
   );
 };

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 114,
+  patchVersion: 115,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
- Topics and words are now within a `ul`, making it easier for user to know that these elements are related to each other and how many there are.
- Topic titles and word labels now within an `h2` (not necessary, to be discussed)
- Breadcrumbs are now within an `ol` and `nav` to be more organized and highlight that these are navigational links.
- Languages (favorites and selector) are now placed within an `ul` and `nav` making it easier for user to know that this is a section and how many items it contains, and that these are navigational links.