### PR TITLE
Hide nav in header on small screens

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 118,
+  "patchVersion": 119,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Header/Header.module.scss
+++ b/h5p-bildetema/src/components/Header/Header.module.scss
@@ -57,6 +57,18 @@
   justify-content: flex-end;
 }
 
+.languages_nav {
+  display: none;
+
+  @include breakpoint-min($medium) {
+    display: block;
+  }
+
+  @media print {
+    display: block;
+  }
+}
+
 .logo_oslomet {
   display: flex;
   justify-self: flex-start;
@@ -125,18 +137,10 @@
 .languages {
   justify-content: center;
   align-items: center;
-  display: none;
+  display: flex;
   gap: $spacing--8;
   flex-wrap: wrap;
   margin: 0;
-
-  @include breakpoint-min($medium) {
-    display: flex;
-  }
-
-  @media print {
-    display: flex;
-  }
 
   li {
     list-style-type: none;

--- a/h5p-bildetema/src/components/Header/Header.tsx
+++ b/h5p-bildetema/src/components/Header/Header.tsx
@@ -115,7 +115,7 @@ export const Header: React.FC<HeaderProps> = ({
           <span className={styles.logo_labels_subtitle}>{subTitleLabel}</span>
         </Link>
         <div className={styles.language_container}>
-          <nav aria-label={navAriaLabel}>
+          <nav aria-label={navAriaLabel} className={styles.languages_nav}>
             <ul role="list" className={styles.languages}>
               {favLanguages.map(language => {
                 return (

--- a/h5p-bildetema/src/components/TopicGridElementAudio/TopicGridElementAudio.module.scss
+++ b/h5p-bildetema/src/components/TopicGridElementAudio/TopicGridElementAudio.module.scss
@@ -12,6 +12,7 @@
 .wordAudio button {
   all: unset;
   cursor: pointer;
+  height: 1.5rem;
 }
 
 .audioIcon,

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 118,
+  patchVersion: 119,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Now that languages is placed inside a `nav`, hide that one instead of the language (ul) element