### PR TITLE
Add about link in footer

### DIFF
--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -41,6 +41,14 @@
           "default": "Pause audio"
         },
         {
+          "label": "About label",
+          "default": "About Bildetema"
+        },
+        {
+          "label": "About URL",
+          "default": "/about-bildetema"
+        },
+        {
           "label": "Footer contact info label",
           "default": "Contact us"
         },

--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -41,6 +41,14 @@
           "default": "Sett lyd på pause"
         },
         {
+          "label": "Footer: Om Bildetema tekst",
+          "default": "Om Bildetema"
+        },
+        {
+          "label": "Footer: Om Bildetema URL",
+          "default": "/om-bildetema"
+        },
+        {
           "label": "Footer: Kontaktinfo-overskrift",
           "default": "Kontakt oss"
         },

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -41,6 +41,14 @@
           "default": "Pause audio"
         },
         {
+          "label": "Footer: Om Bildetema tekst",
+          "default": "Om Bildetema"
+        },
+        {
+          "label": "Footer: Om Bildetema URL",
+          "default": "/om-bildetema"
+        },
+        {
           "label": "Footer contact info label",
           "default": "Contact us"
         },

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 133,
+  "patchVersion": 134,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -61,6 +61,18 @@
         "type": "text"
       },
       {
+        "label": "Footer about label",
+        "name": "footerAboutLabel",
+        "default": "About Bildetema",
+        "type": "text"
+      },
+      {
+        "label": "Footer about URL",
+        "name": "footerAboutHref",
+        "default": "/about-bildetema",
+        "type": "text"
+      },
+      {
         "label": "Footer contact info label",
         "name": "footerContactInfoLabel",
         "default": "Contact us",

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -69,7 +69,7 @@
       {
         "label": "Footer about URL",
         "name": "footerAboutHref",
-        "default": "/about-bildetema",
+        "default": "/om-bildetema",
         "type": "text"
       },
       {

--- a/h5p-bildetema/src/components/Footer/Footer.tsx
+++ b/h5p-bildetema/src/components/Footer/Footer.tsx
@@ -3,6 +3,9 @@ import { useL10n } from "../../hooks/useL10n";
 import styles from "./Footer.module.scss";
 
 export const Footer = (): JSX.Element => {
+  const aboutLabel = useL10n("footerAboutLabel");
+  const aboutHref = useL10n("footerAboutHref");
+
   const contactInfoLabel = useL10n("footerContactInfoLabel");
   const contactInfoHref = useL10n("footerContactInfoHref");
 
@@ -22,6 +25,9 @@ export const Footer = (): JSX.Element => {
   return (
     <footer role="contentinfo" className={styles.footer}>
       <nav aria-label={navAriaLabel} className={styles.footer_content}>
+        <a href={aboutHref} className={styles.hide_from_print}>
+          {aboutLabel}
+        </a>
         <a href={contactInfoHref} className={styles.hide_from_print}>
           {contactInfoLabel}
         </a>

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 133,
+  patchVersion: 134,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-bildetema/src/semantics.ts
+++ b/h5p-bildetema/src/semantics.ts
@@ -83,6 +83,18 @@ export const semantics: Readonly<Array<H5PField | H5PBehaviour | H5PL10n>> = [
         type: "text",
       },
       {
+        label: "Footer about label",
+        name: "footerAboutLabel",
+        default: "About Bildetema",
+        type: "text",
+      },
+      {
+        label: "Footer about URL",
+        name: "footerAboutHref",
+        default: "/about-bildetema",
+        type: "text",
+      },
+      {
         label: "Footer contact info label",
         name: "footerContactInfoLabel",
         default: "Contact us",

--- a/h5p-bildetema/src/semantics.ts
+++ b/h5p-bildetema/src/semantics.ts
@@ -91,7 +91,7 @@ export const semantics: Readonly<Array<H5PField | H5PBehaviour | H5PL10n>> = [
       {
         label: "Footer about URL",
         name: "footerAboutHref",
-        default: "/about-bildetema",
+        default: "/om-bildetema",
         type: "text",
       },
       {

--- a/h5p-bildetema/src/types/TranslationKey.ts
+++ b/h5p-bildetema/src/types/TranslationKey.ts
@@ -14,6 +14,8 @@ export type TranslationKey =
   | "printImgLabel"
   | "playAudio"
   | "pauseAudio"
+  | "footerAboutLabel"
+  | "footerAboutHref"
   | "footerContactInfoLabel"
   | "footerContactInfoHref"
   | "footerLink1Label"


### PR DESCRIPTION
If the page is not added to an environment or language, we should provide an ok 404-page. But perhaps the default url should be "/om-bildetema" and not in english "/about-bildetema" 