### PR TITLE
Avoid overriding document title when not necessary

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 134,
+  "patchVersion": 135,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -138,7 +138,7 @@ export const Bildetema: React.FC<BildetemaProps> = ({
   }, [favLanguages, userData, setUserData]);
 
   useEffect(() => {
-    if (document.title !== pageTitle) {
+    if (document.title === "") {
       document.title = pageTitle;
     }
   });

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 134,
+  patchVersion: 135,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Could be good to keep it for localhost (not only displaying the url as the page name) but we don't need it for WordPress. There it will be better to actually use the page name and be able to change it.