### PR TITLE
Make sure styling is not overrided by WordPress

### DIFF
--- a/common/abstracts/_variables.scss
+++ b/common/abstracts/_variables.scss
@@ -20,6 +20,8 @@ $medium: 64rem;
 $large: 75rem;
 $x-large: 90rem;
 
+$black: #000000;
+$white: #ffffff;
 $grey: #eee;
 $beige: #f6f5f4;
 $dark-beige: #ebeae8;
@@ -27,6 +29,8 @@ $burgundy: #99002b;
 $blue-magenta: #000064;
 $orange: hsla(39, 100%, 50%, 1);
 $orange-overlay: hsla(39, 100%, 50%, 0.25);
+
+$base-font-color: $black;
 
 $topicImageBlueMagentaStroke: rgba(0, 0, 100, 1);
 $topicImageBlueMagentaFill: rgba(0, 0, 100, 0.25);
@@ -53,16 +57,16 @@ $topicImageBlackTransparentHover: rgba(37, 22, 22, 0.45);
 $outline-on-dark-background: 3px solid $orange;
 $outline-on-light-background: 3px solid $burgundy;
 
-$checkbox-color: black;
+$checkbox-color: $black;
 $checkbox-disabled-color: #9c9c99;
 $checkbox-shadow-color: $orange;
-$checkmark-color: white;
+$checkmark-color: $white;
 
 $toggle-on-color: $burgundy;
-$toggle-off-color: white;
-$toggle-slider-on-color: white;
+$toggle-off-color: $white;
+$toggle-slider-on-color: $white;
 $toggle-slider-off-color: $burgundy;
-$toggle-focus-color: black;
+$toggle-focus-color: $black;
 
 $main-content-margin: 0 auto;
 $main-content-max-width: 90rem;

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 58,
+  "patchVersion": 59,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.module.scss
+++ b/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.module.scss
@@ -29,6 +29,7 @@
 }
 
 .word_label {
+  color: $base-font-color;
   font-size: $font-size-24;
   font-weight: normal;
   line-height: 1.4;

--- a/h5p-bildetema-words-grid-view/src/library.ts
+++ b/h5p-bildetema-words-grid-view/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaWordsGridView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 58,
+  patchVersion: 59,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 59,
+  "patchVersion": 60,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageWordAudio/TopicImageWordAudio.module.scss
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageWordAudio/TopicImageWordAudio.module.scss
@@ -31,6 +31,7 @@
 }
 
 .word_label {
+  color: $base-font-color;
   font-size: $font-size-24;
   line-height: 1.4;
 

--- a/h5p-bildetema-words-topic-image/src/library.ts
+++ b/h5p-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaTopicImageView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 59,
+  patchVersion: 60,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 140,
+  "patchVersion": 141,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.module.scss
@@ -58,6 +58,7 @@
 .link {
   all: unset;
   align-items: center;
+  color: $base-font-color;
   display: flex;
   font-size: $font-size-18;
   gap: 0.5rem;
@@ -80,12 +81,12 @@
     padding: 0.375rem 1rem;
 
     &:hover {
-      background-color: #fff;
+      background-color: $white;
       border-color: $burgundy;
       color: $burgundy;
     }
     &:focus {
-      background-color: #fff;
+      background-color: $white;
       color: $burgundy;
 
       &:hover {
@@ -109,6 +110,7 @@
 
   & svg,
   &Left svg {
+    color: $base-font-color;
     height: 1.063rem;
     width: 0.625rem;
   }
@@ -161,10 +163,12 @@
 }
 
 .currentPage {
-  font-size: 1.5rem;
-  font-weight: bold;
-  line-height: 1;
-  margin: 0.5rem 0;
+  color: $base-font-color;
+  font-size: 1.5rem !important;
+  font-weight: bold !important;
+  line-height: 1 !important;
+  margin: 0.5rem 0 !important;
+  padding: 0 !important;
   word-break: break-all;
 }
 

--- a/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
+++ b/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
@@ -26,6 +26,16 @@
     left: 50%;
     top: 50%;
     transform: translate(-50%, -50%);
+
+    &:focus {
+      border-color: none;
+      box-shadow: none;
+      outline: $outline-on-light-background !important;
+    }
+
+    &:checked::before {
+      content: none;
+    }
   }
 }
 

--- a/h5p-bildetema/src/components/Footer/Footer.module.scss
+++ b/h5p-bildetema/src/components/Footer/Footer.module.scss
@@ -46,6 +46,7 @@
 
     li {
       list-style: none;
+      margin: 0;
     }
   }
 

--- a/h5p-bildetema/src/components/Footer/Footer.module.scss
+++ b/h5p-bildetema/src/components/Footer/Footer.module.scss
@@ -29,7 +29,7 @@
     gap: $spacing--16;
 
     h2 {
-      color: white;
+      color: $white;
       font-size: $font-size-20;
       font-weight: bold;
       line-height: 1.4;
@@ -53,15 +53,20 @@
   p {
     margin-block-start: 0;
     margin-block-end: 0;
-    color: white;
+    color: $white;
   }
 
   a {
+    line-height: 1.4;
     text-decoration: underline;
     text-underline-offset: 0.25rem;
 
     &:hover {
       text-decoration: none;
+    }
+
+    &:focus {
+      box-shadow: none;
     }
   }
 

--- a/h5p-bildetema/src/components/Header/Header.module.scss
+++ b/h5p-bildetema/src/components/Header/Header.module.scss
@@ -32,7 +32,7 @@
 
   &_content {
     align-items: flex-start;
-    color: white;
+    color: $white;
     display: flex;
     gap: $spacing--16;
     justify-content: flex-start;
@@ -96,7 +96,7 @@
 }
 
 .logo_labels {
-  color: white;
+  color: $white;
   display: flex;
   flex-direction: column;
   font-size: $font-size-16;
@@ -112,10 +112,13 @@
   }
 
   &:hover {
+    color: $white;
     text-decoration: none;
   }
 
   &:focus {
+    box-shadow: none;
+    color: $white;
     outline: $outline-on-dark-background !important;
   }
 
@@ -150,8 +153,8 @@
 
 .languageButton {
   background-color: transparent;
-  border-bottom: 0.1rem solid #fff;
-  color: white;
+  border-bottom: 0.1rem solid $white;
+  color: $white;
   cursor: pointer;
   font-size: $font-size-18;
   line-height: 1;
@@ -161,18 +164,21 @@
   white-space: nowrap;
 
   &:hover {
+    color: $white;
     border-color: transparent;
     text-decoration: none;
   }
 
   &:focus {
+    box-shadow: none;
+    color: $white;
     outline: $outline-on-dark-background !important;
     outline-offset: 2px;
   }
 
   &_active,
   &.active {
-    background-color: #fff;
+    background-color: $white;
     border-color: transparent;
     border-radius: 0.5rem;
     color: $burgundy;
@@ -180,13 +186,18 @@
     padding: 0.35rem 0.5rem 0.25rem;
     text-decoration: none;
 
+    &:hover {
+      color: $burgundy;
+    }
+
     &:focus {
+      color: $burgundy;
       outline: $outline-on-dark-background !important;
     }
 
     @media print {
       background-color: transparent;
-      color: #fff;
+      color: $white;
     }
   }
 

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
@@ -44,6 +44,7 @@
 .languageLabel {
   all: unset;
   flex: 1;
+  color: $base-font-color;
   display: flex;
   font-size: $font-size-18;
   cursor: pointer;
@@ -65,5 +66,11 @@
 
   &:hover {
     text-decoration-line: underline;
+  }
+
+  &:hover, 
+  &:focus {
+    box-shadow: none;
+    color: $base-font-color;
   }
 }

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
@@ -19,11 +19,6 @@
   &:focus {
     background: $beige;
   }
-  &.disabled {
-    color: $checkbox-disabled-color;
-    pointer-events: none;
-    user-select: none;
-  }
 
   &:focus-within {
     background: $beige;
@@ -72,5 +67,15 @@
   &:focus {
     box-shadow: none;
     color: $base-font-color;
+  }
+}
+
+.disabled {
+  pointer-events: none;
+  user-select: none;
+
+  &,
+  a {
+    color: $checkbox-disabled-color;
   }
 }

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.module.scss
@@ -68,7 +68,7 @@
     text-decoration-line: underline;
   }
 
-  &:hover, 
+  &:hover,
   &:focus {
     box-shadow: none;
     color: $base-font-color;

--- a/h5p-bildetema/src/components/PrintButton/PrintButton.module.scss
+++ b/h5p-bildetema/src/components/PrintButton/PrintButton.module.scss
@@ -6,6 +6,7 @@
   background-color: $grey;
   border: 2px solid transparent;
   border-radius: 1rem;
+  color: $base-font-color;
   cursor: pointer;
   font-size: $font-size-18;
   font-weight: normal;
@@ -13,7 +14,7 @@
   padding: 0.375rem 1rem;
 
   &:hover {
-    background-color: #fff;
+    background-color: $white;
     border-color: $burgundy;
     color: $burgundy;
   }
@@ -41,7 +42,7 @@
   &:hover {
     background-color: $burgundy;
     border-color: $burgundy;
-    color: #fff;
+    color: $white;
   }
 
   &:hover {
@@ -60,13 +61,13 @@
   position: absolute;
   flex-direction: column;
   margin-top: 0.5rem;
-  background-color: white;
+  background-color: $white;
   min-width: 3rem;
   box-shadow: hsl(206 22% 7% / 35%) 0 10px 38px -10px,
     hsl(206 22% 7% / 20%) 0 10px 20px -15px;
   z-index: $fav-language-selector-z-index;
   padding: 1.25rem;
-  color: black;
+  color: $black;
 }
 
 .show {
@@ -91,6 +92,7 @@
 
 .printDropdownElement {
   all: unset;
+  color: $base-font-color;
   direction: ltr;
   font-size: $font-size-18;
   gap: $spacing--16;

--- a/h5p-bildetema/src/components/Toggle/Toggle.module.scss
+++ b/h5p-bildetema/src/components/Toggle/Toggle.module.scss
@@ -13,6 +13,7 @@
 }
 
 .label {
+  color: $base-font-color;
   font-weight: normal;
   line-height: 1;
 }

--- a/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
+++ b/h5p-bildetema/src/components/TopicGridElement/TopicGridElement.module.scss
@@ -9,7 +9,7 @@
   font-size: $font-size-18;
   font-weight: bold;
   line-height: 1.4;
-  color: black;
+  color: $base-font-color;
   width: 100%;
   transition-duration: 0.2s;
   box-sizing: border-box;
@@ -30,6 +30,7 @@
   }
 
   h2 {
+    color: $base-font-color;
     font-size: inherit;
     font-weight: inherit;
     line-height: inherit;
@@ -57,6 +58,10 @@
   &:hover {
     text-decoration: none;
     background-color: $dark-beige;
+  }
+
+  &:focus {
+    box-shadow: none;
   }
 }
 

--- a/h5p-bildetema/src/components/TopicSizeButtons/TopicSizeButtons.module.scss
+++ b/h5p-bildetema/src/components/TopicSizeButtons/TopicSizeButtons.module.scss
@@ -15,7 +15,7 @@
   background-color: #eee;
   border: 2px solid transparent;
   border-radius: 0.5rem;
-  color: #000;
+  color: $base-font-color;
   cursor: pointer;
   line-height: 50%;
   min-width: 2.5rem;
@@ -32,13 +32,13 @@
   }
 
   &:hover {
-    background-color: #fff;
+    background-color: $white;
     border-color: $burgundy;
     color: $burgundy;
   }
 
   &:focus {
-    background-color: #fff;
+    background-color: $white;
     color: $burgundy;
 
     &:hover {
@@ -47,13 +47,13 @@
   }
 
   &.active {
-    color: white;
+    color: $white;
     background-color: $burgundy;
     pointer-events: none;
 
     path {
-      fill: white;
-      stroke: white;
+      fill: $white;
+      stroke: $white;
     }
   }
 }

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 140,
+  patchVersion: 141,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 48,
+  "patchVersion": 49,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/src/library.ts
+++ b/h5p-editor-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5PEditor.BildetemaWordsTopicImage",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 48,
+  patchVersion: 49,
   runnable: 0,
   preloadedJs: [
     {


### PR DESCRIPTION
Avoid getting blue font color on hover, blue box-shadow on focus etc, when previewing the H5P in WordPress:

<img width="666" alt="Skjermbilde 2022-11-29 kl  10 29 40" src="https://user-images.githubusercontent.com/35261194/204491678-d65a08b5-07f0-4d5b-8786-93f133fcfb56.png">
<img width="485" alt="Skjermbilde 2022-11-29 kl  10 29 46" src="https://user-images.githubusercontent.com/35261194/204491685-cbba34b7-82e7-4b70-a86b-1d561fcbef15.png">
