### PR TITLE
Move topic image above word list on mobile

### DIFF
--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 60,
+  "patchVersion": 61,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageContainer/TopicImageContainer.module.scss
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageContainer/TopicImageContainer.module.scss
@@ -2,8 +2,13 @@
 
 .wrapper {
   display: flex;
+  flex-direction: column;
   gap: $spacing--16;
   width: 100%;
+
+  @include breakpoint-min($x-small) {
+    flex-direction: row;
+  }
 
   :focus {
     outline: $outline-on-light-background;

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
@@ -37,7 +37,11 @@
 .imageContainer {
   position: relative;
   max-height: calc(100vh - 5rem); // Compensate for mobile header height
-  width: 80%;
+  width: 100%;
+
+  @include breakpoint-min($x-small) {
+    width: 80%;
+  }
 
   @include breakpoint-min($small) {
     max-height: calc(100vh - 11rem); // Compensate for header height

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageWordList/TopicImageWordList.module.scss
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageWordList/TopicImageWordList.module.scss
@@ -1,9 +1,15 @@
 @use "../../../../common/abstracts" as *;
 
 .topicImageWordList {
-  max-width: 20rem;
-  margin: 0 auto 0 0;
   height: 100%;
+  margin: 0 auto 0 0;
+  max-width: 100%;
+  order: 1;
+
+  @include breakpoint-min($x-small) {
+    max-width: 20rem;
+    order: 0;
+  }
 
   [class*="rtl"] & {
     margin: 0 0 0 auto;

--- a/h5p-bildetema-words-topic-image/src/library.ts
+++ b/h5p-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaTopicImageView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 60,
+  patchVersion: 61,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Provides a bigger image on mobile that can use the whole screen width instead of a tiny image that is difficult to tap on