### PR TITLE
Fix topic image img height

### DIFF
--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 62,
+  "patchVersion": 63,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
@@ -57,6 +57,7 @@
 
 .imageVertical {
   height: 100%;
+  max-height: calc(100vh - 5rem);
 }
 
 .imageHorizontal {

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageSVG/TopicImageSVG.module.scss
@@ -44,7 +44,7 @@
     width: 80%;
   }
 
-  @include breakpoint-min($small) {
+  @include breakpoint-min($medium) {
     max-height: calc(100vh - 11rem); // Compensate for header height
   }
 }
@@ -57,7 +57,7 @@
 
 .imageVertical {
   height: 100%;
-  max-height: calc(100vh - 5rem);
+  max-height: calc(100vh - 5rem); // Compensate for mobile header height
 }
 
 .imageHorizontal {

--- a/h5p-bildetema-words-topic-image/src/library.ts
+++ b/h5p-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaTopicImageView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 62,
+  patchVersion: 63,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Fix for all browsers

also changes the breakpoint for the max-height from small to medium, since that is when the shift actually happens in the header