### PR TITLE
Fix lang attribute placement

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 152,
+  "patchVersion": 153,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -23,7 +23,7 @@ import styles from "./Bildetema.module.scss";
 import { MainContentLink } from "../MainContentLink/MainContentLink";
 import { LanguageCode } from "../../../../common/types/LanguageCode";
 import { SearchParameters } from "../../enums/SearchParameters";
-import { useCurrentLanguage } from "../../hooks/useSiteLanguage";
+import { useCurrentLanguage } from "../../hooks/useCurrentLanguage";
 
 type BildetemaProps = {
   defaultLanguages: string[];

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -23,8 +23,7 @@ import styles from "./Bildetema.module.scss";
 import { MainContentLink } from "../MainContentLink/MainContentLink";
 import { LanguageCode } from "../../../../common/types/LanguageCode";
 import { SearchParameters } from "../../enums/SearchParameters";
-import { attributeLanguages } from "../../../../common/constants/languages";
-import { useSiteLanguage } from "../../hooks/useSiteLanguage";
+import { useCurrentLanguage } from "../../hooks/useSiteLanguage";
 
 type BildetemaProps = {
   defaultLanguages: string[];
@@ -37,7 +36,7 @@ export const Bildetema: React.FC<BildetemaProps> = ({
 }) => {
   const { languages: languagesFromDB } = useDBContext() || {};
   const { pathname } = useLocation();
-  const siteLang = useSiteLanguage();
+  const currentLang = useCurrentLanguage();
 
   const [showLoadingLabel, setShowLoadingLabel] = useState(false);
 
@@ -226,7 +225,6 @@ export const Bildetema: React.FC<BildetemaProps> = ({
           id="bildetemaMain"
           className={`${styles.body} ${directionRtl ? styles.rtl : ""}`}
           aria-label={mainContentAriaLabel}
-          lang={attributeLanguages[getCurrentLanguage()?.code] ?? siteLang}
         >
           <SubHeader
             topicIds={topicIds}
@@ -240,7 +238,11 @@ export const Bildetema: React.FC<BildetemaProps> = ({
             handleToggleArticles={handleToggleArticles}
             articlesToggleChecked={showArticles}
           />
-          {isLoadingData ? showLoadingLabel && <p>{loadingLabel}</p> : routes}
+          {isLoadingData ? (
+            showLoadingLabel && <p>{loadingLabel}</p>
+          ) : (
+            <div lang={currentLang}>{routes}</div>
+          )}
         </div>
         <Footer />
       </div>

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -15,10 +15,8 @@ import {
 } from "../Icons/Icons";
 import { labelToUrlComponent } from "../../../../common/utils/string.utils";
 import styles from "./Breadcrumbs.module.scss";
-import {
-  useCurrentLanguage,
-  useSiteLanguage,
-} from "../../hooks/useSiteLanguage";
+import { useSiteLanguage } from "../../hooks/useSiteLanguage";
+import { useCurrentLanguage } from "../../hooks/useCurrentLanguage";
 
 export type BreadcrumbsProps = {
   breadCrumbs?: {

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -15,7 +15,10 @@ import {
 } from "../Icons/Icons";
 import { labelToUrlComponent } from "../../../../common/utils/string.utils";
 import styles from "./Breadcrumbs.module.scss";
-import { useSiteLanguage } from "../../hooks/useSiteLanguage";
+import {
+  useCurrentLanguage,
+  useSiteLanguage,
+} from "../../hooks/useSiteLanguage";
 
 export type BreadcrumbsProps = {
   breadCrumbs?: {
@@ -32,6 +35,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
   topicIds,
 }) => {
   const lang = useSiteLanguage();
+  const currentLang = useCurrentLanguage();
   const { translations, topics } = useDBContext() || {};
   const labelFromDb = getLabelFromTranslationRecord(
     translations?.[currentLanguageCode],
@@ -93,7 +97,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
     const homePageElement = breadCrumbsToRender[0];
 
     return (
-      <div className={styles.breadcrumbs}>
+      <div className={styles.breadcrumbs} lang={currentLang}>
         <h1 className={styles.currentPage} key={homePageElement.path}>
           {homePageElement.label}
         </h1>
@@ -103,7 +107,7 @@ export const Breadcrumbs: React.FC<BreadcrumbsProps> = ({
 
   return (
     <nav aria-label={breadcrumbsAriaLabel}>
-      <ol role="list" className={styles.breadcrumbs}>
+      <ol role="list" className={styles.breadcrumbs} lang={currentLang}>
         {breadCrumbsToRender.map(({ label, path }, index) => {
           const notLastBreadCrumb = index !== breadCrumbsToRender.length - 1;
           const homePageBreadCrumb = index === 0;

--- a/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
+++ b/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
@@ -6,7 +6,6 @@ import { useL10ns } from "../../hooks/useL10n";
 import styles from "./PrintButton.module.scss";
 import { TopicIds } from "../../../../common/types/types";
 import { PrintWords } from "../PrintWords/PrintWords";
-import { useSiteLanguage } from "../../hooks/useSiteLanguage";
 
 type PrintProps = {
   topicIds: TopicIds;
@@ -21,7 +20,6 @@ export const PrintButton: React.FC<PrintProps> = ({
   isWordView,
   showTopicImageView,
 }) => {
-  const lang = useSiteLanguage();
   const [imagesPrRow, setImagesPrRow] = React.useState(3);
   const [printClicked, setPrintClicked] = React.useState(false);
   const [viewPrintDropDown, setViewPrintDropDown] = React.useState(false);
@@ -101,9 +99,7 @@ export const PrintButton: React.FC<PrintProps> = ({
               <PrintIcon />
             </span>
             {printLabel && (
-              <span className={styles.printLabel} lang={lang}>
-                {printLabel}
-              </span>
+              <span className={styles.printLabel}>{printLabel}</span>
             )}
             {(!showTopicImageView || !isWordView) && (
               <span className={styles.arrowIcon} aria-hidden="true">

--- a/h5p-bildetema/src/components/Toggle/Toggle.tsx
+++ b/h5p-bildetema/src/components/Toggle/Toggle.tsx
@@ -2,7 +2,6 @@ import React, { useState } from "react";
 import ReactToggle from "react-toggle";
 import styles from "./Toggle.module.scss";
 import "./ReactToggle.scss";
-import { useSiteLanguage } from "../../hooks/useSiteLanguage";
 
 type ToggleProps = {
   handleChange: (checked: boolean) => void;
@@ -16,7 +15,6 @@ export const Toggle: React.FC<ToggleProps> = ({
   label,
   id,
 }) => {
-  const lang = useSiteLanguage();
   // Show focus when tab/keyboard is used, not on click
   const [isFocused, setIsFocused] = useState(false);
   const handleOnFocus = (showFocus: boolean): void => {
@@ -33,11 +31,7 @@ export const Toggle: React.FC<ToggleProps> = ({
       className={isFocused ? styles.containerFocused : styles.container}
       htmlFor={id}
     >
-      {label && (
-        <span className={styles.label} lang={lang}>
-          {label}
-        </span>
-      )}
+      {label && <span className={styles.label}>{label}</span>}
       <ReactToggle
         id={id}
         checked={checked}

--- a/h5p-bildetema/src/components/TopicSizeButtons/TopicSizeButtons.tsx
+++ b/h5p-bildetema/src/components/TopicSizeButtons/TopicSizeButtons.tsx
@@ -3,7 +3,6 @@ import { TopicGridSizes } from "../../../../common/types/types";
 import { BigTopicsIcon, CompactTopicsIcon } from "../Icons/Icons";
 import { useL10n } from "../../hooks/useL10n";
 import styles from "./TopicSizeButtons.module.scss";
-import { useSiteLanguage } from "../../hooks/useSiteLanguage";
 
 export type TopicSizeButtonsProps = {
   topicsSize: TopicGridSizes;
@@ -23,7 +22,6 @@ export const TopicSizeButtons: React.FC<TopicSizeButtonsProps> = ({
     }
   };
 
-  const lang = useSiteLanguage();
   const bigTopicsLabel = useL10n("bigTopics");
   const compactTopicsLabel = useL10n("compactTopics");
 
@@ -38,9 +36,7 @@ export const TopicSizeButtons: React.FC<TopicSizeButtonsProps> = ({
         tabIndex={topicsSize === TopicGridSizes.Big ? -1 : 0}
       >
         <BigTopicsIcon />
-        <span className={styles.visuallyHidden} lang={lang}>
-          {bigTopicsLabel}
-        </span>
+        <span className={styles.visuallyHidden}>{bigTopicsLabel}</span>
       </button>
       <button
         type="button"
@@ -51,9 +47,7 @@ export const TopicSizeButtons: React.FC<TopicSizeButtonsProps> = ({
         tabIndex={topicsSize === TopicGridSizes.Compact ? -1 : 0}
       >
         <CompactTopicsIcon />
-        <span className={styles.visuallyHidden} lang={lang}>
-          {compactTopicsLabel}
-        </span>
+        <span className={styles.visuallyHidden}>{compactTopicsLabel}</span>
       </button>
     </div>
   );

--- a/h5p-bildetema/src/hooks/useCurrentLanguage.ts
+++ b/h5p-bildetema/src/hooks/useCurrentLanguage.ts
@@ -1,0 +1,14 @@
+import { useLocation } from "react-router-dom";
+import { attributeLanguages } from "../../../common/constants/languages";
+import { LanguageCode } from "../../../common/types/LanguageCode";
+
+export const useCurrentLanguage = (): string => {
+  const { pathname } = useLocation();
+
+  const currentLanguageCode: LanguageCode =
+    pathname.split("/").length >= 2
+      ? (pathname.split("/")[1] as LanguageCode)
+      : "nob";
+
+  return attributeLanguages[currentLanguageCode];
+};

--- a/h5p-bildetema/src/hooks/useSiteLanguage.ts
+++ b/h5p-bildetema/src/hooks/useSiteLanguage.ts
@@ -1,19 +1,5 @@
-import { useLocation } from "react-router-dom";
-import { attributeLanguages } from "../../../common/constants/languages";
-import { LanguageCode } from "../../../common/types/LanguageCode";
 import { useL10n } from "./useL10n";
 
 export const useSiteLanguage = (): string => {
   return useL10n("htmlLanguageCode");
-};
-
-export const useCurrentLanguage = (): string => {
-  const { pathname } = useLocation();
-
-  const currentLanguageCode: LanguageCode =
-    pathname.split("/").length >= 2
-      ? (pathname.split("/")[1] as LanguageCode)
-      : "nob";
-
-  return attributeLanguages[currentLanguageCode];
 };

--- a/h5p-bildetema/src/hooks/useSiteLanguage.ts
+++ b/h5p-bildetema/src/hooks/useSiteLanguage.ts
@@ -1,5 +1,19 @@
+import { useLocation } from "react-router-dom";
+import { attributeLanguages } from "../../../common/constants/languages";
+import { LanguageCode } from "../../../common/types/LanguageCode";
 import { useL10n } from "./useL10n";
 
 export const useSiteLanguage = (): string => {
   return useL10n("htmlLanguageCode");
+};
+
+export const useCurrentLanguage = (): string => {
+  const { pathname } = useLocation();
+
+  const currentLanguageCode: LanguageCode =
+    pathname.split("/").length >= 2
+      ? (pathname.split("/")[1] as LanguageCode)
+      : "nob";
+
+  return attributeLanguages[currentLanguageCode];
 };

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 152,
+  patchVersion: 153,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
The lang attributes was interfering with the new aria-labels that was not in the "current language" but the main language of the page.

This pr moves the "current language" attribute from main content/body to routes and breadcrumbs. Tools (toggle, print and topicSizeButtons) will now inherit from the html lang instead. 