### PR TITLE
Fix some visually hidden not working in Safari

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 165,
+  "patchVersion": 166,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/LanguageDropdown/LanguageDropdown.module.scss
+++ b/h5p-bildetema/src/components/LanguageDropdown/LanguageDropdown.module.scss
@@ -14,7 +14,7 @@
 
 .languageLabel {
   @include breakpoint-max($small) {
-    @include visually-hidden;
+    display: none;
   }
 }
 

--- a/h5p-bildetema/src/components/LanguageDropdown/LanguageDropdown.tsx
+++ b/h5p-bildetema/src/components/LanguageDropdown/LanguageDropdown.tsx
@@ -68,6 +68,7 @@ export const LanguageDropdown: React.FC<LanguageDropdownProps> = ({
       <button
         type="button"
         onClick={handleOnClick}
+        aria-label={selectLanguageLabel}
         className={
           isActive ? styles.languageMenuButtonActive : styles.languageMenuButton
         }

--- a/h5p-bildetema/src/components/PrintButton/PrintButton.module.scss
+++ b/h5p-bildetema/src/components/PrintButton/PrintButton.module.scss
@@ -119,6 +119,6 @@
 
 .printLabel {
   @include breakpoint-max($small) {
-    @include visually-hidden;
+    display: none;
   }
 }

--- a/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
+++ b/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
@@ -81,6 +81,7 @@ export const PrintButton: React.FC<PrintProps> = ({
       >
         <button
           type="button"
+          aria-label={printLabel}
           className={`${
             isActive ? styles.printButtonActive : styles.printButton
           } ${

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 165,
+  patchVersion: 166,
   runnable: 1,
   preloadedJs: [
     {


### PR DESCRIPTION
Noticed two places where the visually-hidden was used, that it did work properly in Safari. Both of these instances used visually-hidden for the button label and only on smaller screens. 

When on a laptop (or large screen) and sizing the browser window down to the breakpoint, the labels are hidden but the size of the button is not adjusted before the mouse hoveres over the button (language button) or it does not get adjusted at all (print button). 

Seems safer to use `display: none` for these instances. 

<img width="671" alt="Skjermbilde 2023-01-04 kl  11 04 09" src="https://user-images.githubusercontent.com/35261194/210537908-bf9b185a-ce1e-495a-b2a0-efdaf3311a99.png">
<img width="788" alt="Skjermbilde 2023-01-04 kl  11 04 25" src="https://user-images.githubusercontent.com/35261194/210537915-28e7a948-582a-46c2-a656-d6c2e251952e.png">
<img width="731" alt="Skjermbilde 2023-01-04 kl  11 45 33" src="https://user-images.githubusercontent.com/35261194/210538725-b3f2aefe-b0e2-418e-b118-1d181ee2c839.png">

