### PR TITLE
Fix label and contrast error in language selector

### DIFF
--- a/common/abstracts/_variables.scss
+++ b/common/abstracts/_variables.scss
@@ -58,7 +58,7 @@ $outline-on-dark-background: 3px solid $orange;
 $outline-on-light-background: 3px solid $burgundy;
 
 $checkbox-color: $black;
-$checkbox-disabled-color: #9c9c99;
+$checkbox-disabled-color: #767674;
 $checkbox-shadow-color: $orange;
 $checkmark-color: $white;
 

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 65,
+  "patchVersion": 66,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/src/library.ts
+++ b/h5p-bildetema-words-grid-view/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaWordsGridView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 65,
+  patchVersion: 66,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 69,
+  "patchVersion": 70,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/src/library.ts
+++ b/h5p-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.BildetemaTopicImageView",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 69,
+  patchVersion: 70,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 166,
+  "patchVersion": 167,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
+++ b/h5p-bildetema/src/components/Checkbox/Checkbox.module.scss
@@ -43,3 +43,7 @@
   height: 1.75rem;
   width: 1.75rem;
 }
+
+.visuallyHidden {
+  @include visually-hidden;
+}

--- a/h5p-bildetema/src/components/Checkbox/Checkbox.tsx
+++ b/h5p-bildetema/src/components/Checkbox/Checkbox.tsx
@@ -26,7 +26,6 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           checked={checked}
           onChange={e => handleChange(e.target.checked)}
           disabled={disabled}
-          aria-label={label}
         />
         {checked ? (
           <span className={styles.starIcon} aria-hidden="true">
@@ -38,6 +37,7 @@ export const Checkbox: React.FC<CheckboxProps> = ({
           </span>
         )}
       </span>
+      <span className={styles.visuallyHidden}>{label}</span>
     </label>
   );
 };

--- a/h5p-bildetema/src/library.ts
+++ b/h5p-bildetema/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5P.Bildetema",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 166,
+  patchVersion: 167,
   runnable: 1,
   preloadedJs: [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 55,
+  "patchVersion": 56,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/src/library.ts
+++ b/h5p-editor-bildetema-words-topic-image/src/library.ts
@@ -5,7 +5,7 @@ export const library: Library = {
   machineName: "H5PEditor.BildetemaWordsTopicImage",
   majorVersion: 1,
   minorVersion: 0,
-  patchVersion: 55,
+  patchVersion: 56,
   runnable: 0,
   preloadedJs: [
     {


### PR DESCRIPTION
Fix errors:
- Empty form label (checkbox labels)
- Very low contrast (grey disabled color)

Was noticed when using WAVE Evaluation Tool (Chrome extension) and having the language selector open.
<img width="353" alt="Skjermbilde 2023-01-05 kl  14 35 47" src="https://user-images.githubusercontent.com/35261194/210792401-fcd27fc4-68b2-4bf7-bf39-04fcc75cd200.png">