### PR TITLE
feat: sort languages alphabetically

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 184,
+  "patchVersion": 185,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.tsx
@@ -1,5 +1,8 @@
 /* eslint-disable jsx-a11y/no-redundant-roles */
-import { languages as languagesConst, languagesOriginal } from "common/constants/languages";
+import {
+  languages as languagesConst,
+  languagesOriginal,
+} from "common/constants/languages";
 import { useDBContext } from "common/hooks/useDBContext";
 import { Language, TopicIds } from "common/types/types";
 import { LanguageCode } from "common/types/LanguageCode";
@@ -44,7 +47,7 @@ export const LanguageSelector: FC<LanguageSelectorProps> = ({
 
   const translations = useL10ns(...languageKeys, "selectLanguage");
 
-  const getTranslatedLabel = (language: Language): string => {
+  const translatedLabel = (language: Language): string => {
     return translations[`lang_${language.code}`];
   };
 
@@ -53,7 +56,7 @@ export const LanguageSelector: FC<LanguageSelectorProps> = ({
       <ul role="list" className={styles.languageSelector}>
         {languages
           ?.filter(language => languagesOriginal?.[language.code])
-          ?.sort((a, b) => getTranslatedLabel(a).localeCompare(getTranslatedLabel(b)))
+          ?.sort((a, b) => translatedLabel(a).localeCompare(translatedLabel(b)))
           ?.map((language, index) => (
             <LanguageSelectorElement
               path={getLanguagePath(language, topicIds, search, topicsFromDB)}
@@ -64,7 +67,7 @@ export const LanguageSelector: FC<LanguageSelectorProps> = ({
               handleToggleFavoriteLanguage={handleToggleFavoriteLanguage}
               currentLanguageCode={currentLanguageCode}
               translations={translations}
-              translatedLabel={getTranslatedLabel(language)}
+              translatedLabel={translatedLabel(language)}
             />
           ))}
       </ul>

--- a/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.tsx
+++ b/h5p-bildetema/src/components/LanguageSelector/LanguageSelector.tsx
@@ -1,9 +1,11 @@
 /* eslint-disable jsx-a11y/no-redundant-roles */
-import { languagesOriginal } from "common/constants/languages";
+import { languages as languagesConst, languagesOriginal } from "common/constants/languages";
 import { useDBContext } from "common/hooks/useDBContext";
 import { Language, TopicIds } from "common/types/types";
+import { LanguageCode } from "common/types/LanguageCode";
 import { getLanguagePath } from "common/utils/router.utils";
 import { FC } from "react";
+import { useL10ns } from "use-h5p";
 import { useL10n } from "../../hooks/useL10n";
 import { filterURL } from "../../utils/url.utils";
 import { LanguageSelectorElement } from "../LanguageSelectorElement/LanguageSelectorElement";
@@ -36,11 +38,22 @@ export const LanguageSelector: FC<LanguageSelectorProps> = ({
   const linkHref = useL10n("footerPrevBildetemaHref");
   const filteredLinkHref = filterURL(linkHref);
 
+  const languageKeys = languagesConst.map(
+    lang => `lang_${lang}`,
+  ) as Array<`lang_${LanguageCode}`>;
+
+  const translations = useL10ns(...languageKeys, "selectLanguage");
+
+  const getTranslatedLabel = (language: Language): string => {
+    return translations[`lang_${language.code}`];
+  };
+
   return (
     <nav aria-label={navAriaLabel} className={styles.languageSelectorWrapper}>
       <ul role="list" className={styles.languageSelector}>
         {languages
           ?.filter(language => languagesOriginal?.[language.code])
+          ?.sort((a, b) => getTranslatedLabel(a).localeCompare(getTranslatedLabel(b)))
           ?.map((language, index) => (
             <LanguageSelectorElement
               path={getLanguagePath(language, topicIds, search, topicsFromDB)}
@@ -50,6 +63,8 @@ export const LanguageSelector: FC<LanguageSelectorProps> = ({
               favLanguages={favLanguages}
               handleToggleFavoriteLanguage={handleToggleFavoriteLanguage}
               currentLanguageCode={currentLanguageCode}
+              translations={translations}
+              translatedLabel={getTranslatedLabel(language)}
             />
           ))}
       </ul>

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.stories.tsx
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.stories.tsx
@@ -23,6 +23,9 @@ const Template = (
   const handleToggleFavoriteLanguage = (lang: Language, fav: boolean): void => {
     console.info(fav);
   };
+  const translations: Record<string, string> = {
+    selectLanguage: "",
+  };
 
   return (
     <LanguageSelectorElement
@@ -32,6 +35,8 @@ const Template = (
       currentLanguageCode=""
       middleElement={middleElement}
       favLanguages={favLanguages}
+      translations={translations}
+      translatedLabel=""
     />
   );
 };

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.tsx
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.tsx
@@ -1,13 +1,10 @@
 import {
   attributeLanguages,
-  languages,
   languagesOriginal,
 } from "common/constants/languages";
-import { LanguageCode } from "common/types/LanguageCode";
 import { Language } from "common/types/types";
 import { FC } from "react";
 import { Link } from "react-router-dom";
-import { useL10ns } from "use-h5p";
 import { useL10n } from "../../hooks/useL10n";
 import { Checkbox } from "../Checkbox/Checkbox";
 import styles from "./LanguageSelectorElement.module.scss";
@@ -18,6 +15,8 @@ type LanguageSelectorElement = {
   currentLanguageCode: string;
   middleElement: boolean;
   favLanguages: Language[];
+  translations: Record<string, string>;
+  translatedLabel: string;
   handleToggleFavoriteLanguage: (language: Language, favorite: boolean) => void;
 };
 
@@ -27,12 +26,10 @@ export const LanguageSelectorElement: FC<LanguageSelectorElement> = ({
   currentLanguageCode,
   middleElement,
   favLanguages,
+  translations,
+  translatedLabel,
   handleToggleFavoriteLanguage,
 }) => {
-  const languageKeys = languages.map(
-    lang => `lang_${lang}`,
-  ) as Array<`lang_${LanguageCode}`>;
-
   const isChecked = !!favLanguages.find(
     favLang => favLang.code === language.code,
   );
@@ -42,8 +39,6 @@ export const LanguageSelectorElement: FC<LanguageSelectorElement> = ({
   const isDisabled =
     currentLanguageCode === language.code ||
     (isChecked && favLanguages.length < 2);
-
-  const translations = useL10ns(...languageKeys, "selectLanguage");
 
   const languageAriaPart1 = useL10n("chooseFavoriteLanguageAriaLabelPart1");
   const languageAriaPart2 = useL10n("chooseFavoriteLanguageAriaLabelPart2");
@@ -60,9 +55,8 @@ export const LanguageSelectorElement: FC<LanguageSelectorElement> = ({
     // eslint-disable-next-line jsx-a11y/no-redundant-roles
     <li
       role="listitem"
-      className={`${middleElement ? styles.languageMiddle : styles.language} ${
-        isDisabled ? styles.disabled : ""
-      }`}
+      className={`${middleElement ? styles.languageMiddle : styles.language} ${isDisabled ? styles.disabled : ""
+        }`}
     >
       <span className={styles.checkboxWrapper}>
         <Checkbox
@@ -80,7 +74,7 @@ export const LanguageSelectorElement: FC<LanguageSelectorElement> = ({
         to={path}
         tabIndex={isDisabled ? -1 : 0}
       >
-        <span>{translations[`lang_${language.code}`]}</span>
+        <span>{translatedLabel}</span>
         <span lang={attributeLanguages[language.code]}>
           {languagesOriginal[language.code]}
         </span>

--- a/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.tsx
+++ b/h5p-bildetema/src/components/LanguageSelectorElement/LanguageSelectorElement.tsx
@@ -55,8 +55,9 @@ export const LanguageSelectorElement: FC<LanguageSelectorElement> = ({
     // eslint-disable-next-line jsx-a11y/no-redundant-roles
     <li
       role="listitem"
-      className={`${middleElement ? styles.languageMiddle : styles.language} ${isDisabled ? styles.disabled : ""
-        }`}
+      className={`${middleElement ? styles.languageMiddle : styles.language} ${
+        isDisabled ? styles.disabled : ""
+      }`}
     >
       <span className={styles.checkboxWrapper}>
         <Checkbox


### PR DESCRIPTION
Sort the languages in the language selector alphabetically for each chosen language. Currently the placement from the db is used on all languages.