### PR TITLE
ci: check only root package for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,22 +8,6 @@ updates:
     labels:
       - non-functional
 
-  - directory: /h5p-bildetema
-    package-ecosystem: npm
-    rebase-strategy: auto
-    schedule:
-      interval: weekly
-    labels:
-      - non-functional
-
-  - directory: /h5p-bildetema-words-grid-view
-    package-ecosystem: npm
-    rebase-strategy: auto
-    schedule:
-      interval: weekly
-    labels:
-      - non-functional
-
   - directory: /
     package-ecosystem: github-actions
     rebase-strategy: auto


### PR DESCRIPTION
Dependabot is smart enough to check all packages in a monorepo.