### PR TITLE
Fix: typeerror and add filter to favLanguages

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 190,
+  "patchVersion": 191,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -19,6 +19,7 @@ import { LanguageFavorites } from "../LanguageFavorites/LanguageFavorites";
 import { MainContentLink } from "../MainContentLink/MainContentLink";
 import { RouteController } from "../RouteController/RouteController";
 import { SubHeader } from "../SubHeader/SubHeader";
+import { filterFavoriteLanguages } from "../../utils/language.utils";
 import styles from "./Bildetema.module.scss";
 
 type BildetemaProps = {
@@ -153,9 +154,12 @@ export const Bildetema: FC<BildetemaProps> = ({
   );
 
   useEffect(() => {
-    userData.favoriteLanguages = favLanguages;
+    userData.favoriteLanguages = filterFavoriteLanguages(
+      favLanguages,
+      languagesFromDB,
+    );
     setUserData(userData);
-  }, [favLanguages, userData, setUserData]);
+  }, [favLanguages, userData, setUserData, languagesFromDB]);
 
   useEffect(() => {
     if (document.title !== pageTitle) {

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -19,7 +19,7 @@ import { LanguageFavorites } from "../LanguageFavorites/LanguageFavorites";
 import { MainContentLink } from "../MainContentLink/MainContentLink";
 import { RouteController } from "../RouteController/RouteController";
 import { SubHeader } from "../SubHeader/SubHeader";
-import { filterFavoriteLanguages } from "../../utils/language.utils";
+import { sanitizeLanguages } from "../../utils/language.utils";
 import styles from "./Bildetema.module.scss";
 
 type BildetemaProps = {
@@ -154,7 +154,7 @@ export const Bildetema: FC<BildetemaProps> = ({
   );
 
   useEffect(() => {
-    userData.favoriteLanguages = filterFavoriteLanguages(
+    userData.favoriteLanguages = sanitizeLanguages(
       favLanguages,
       languagesFromDB,
     );

--- a/h5p-bildetema/src/components/Header/Header.tsx
+++ b/h5p-bildetema/src/components/Header/Header.tsx
@@ -121,10 +121,11 @@ export const Header: FC<HeaderProps> = ({
           <nav aria-label={navAriaLabel} className={styles.languages_nav}>
             <ul role="list" className={styles.languages}>
               {favLanguages
-                .sort((a, b) =>
-                  translatedLabel(a, langs).localeCompare(
-                    translatedLabel(b, langs),
-                  ),
+                .sort(
+                  (a, b) =>
+                    translatedLabel(a, langs)?.localeCompare(
+                      translatedLabel(b, langs),
+                    ),
                 )
                 .map(language => {
                   return (

--- a/h5p-bildetema/src/components/Header/Header.tsx
+++ b/h5p-bildetema/src/components/Header/Header.tsx
@@ -15,10 +15,7 @@ import {
 } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useL10n, useL10ns } from "../../hooks/useL10n";
-import {
-  filterFavoriteLanguages,
-  translatedLabel,
-} from "../../utils/language.utils";
+import { sanitizeLanguages, translatedLabel } from "../../utils/language.utils";
 import { LanguageDropdown } from "../LanguageDropdown/LanguageDropdown";
 import { OsloMetLogo } from "../Logos/Logos";
 import styles from "./Header.module.scss";
@@ -107,7 +104,7 @@ export const Header: FC<HeaderProps> = ({
     };
   }, [handleIsMobile]);
 
-  const filteredFavLanguages = filterFavoriteLanguages(
+  const sanitizedFavLanguages = sanitizeLanguages(
     favLanguages,
     languagesFromDB,
   );
@@ -129,7 +126,7 @@ export const Header: FC<HeaderProps> = ({
         <div className={styles.language_container}>
           <nav aria-label={navAriaLabel} className={styles.languages_nav}>
             <ul role="list" className={styles.languages}>
-              {filteredFavLanguages
+              {sanitizedFavLanguages
                 .sort(
                   (a, b) =>
                     translatedLabel(a, langs)?.localeCompare(

--- a/h5p-bildetema/src/components/Header/Header.tsx
+++ b/h5p-bildetema/src/components/Header/Header.tsx
@@ -15,7 +15,10 @@ import {
 } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { useL10n, useL10ns } from "../../hooks/useL10n";
-import { translatedLabel } from "../../utils/language.utils";
+import {
+  filterFavoriteLanguages,
+  translatedLabel,
+} from "../../utils/language.utils";
 import { LanguageDropdown } from "../LanguageDropdown/LanguageDropdown";
 import { OsloMetLogo } from "../Logos/Logos";
 import styles from "./Header.module.scss";
@@ -40,7 +43,8 @@ export const Header: FC<HeaderProps> = ({
     lang => `lang_${lang}`,
   ) as Array<LanguageCodeString>;
 
-  const { topics: topicsFromDB } = useDBContext() || {};
+  const { topics: topicsFromDB, languages: languagesFromDB } =
+    useDBContext() || {};
   const { selectLanguage, headerTitle, headerSubtitle, ...langs } = useL10ns(
     "selectLanguage",
     "headerTitle",
@@ -103,6 +107,11 @@ export const Header: FC<HeaderProps> = ({
     };
   }, [handleIsMobile]);
 
+  const filteredFavLanguages = filterFavoriteLanguages(
+    favLanguages,
+    languagesFromDB,
+  );
+
   return (
     <div ref={headerRef} className={styles.header}>
       <div className={styles.header_content}>
@@ -120,7 +129,7 @@ export const Header: FC<HeaderProps> = ({
         <div className={styles.language_container}>
           <nav aria-label={navAriaLabel} className={styles.languages_nav}>
             <ul role="list" className={styles.languages}>
-              {favLanguages
+              {filteredFavLanguages
                 .sort(
                   (a, b) =>
                     translatedLabel(a, langs)?.localeCompare(

--- a/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
+++ b/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
@@ -39,8 +39,11 @@ export const LanguageFavorites: FC<LanguageFavoritesProps> = ({
     <nav aria-label={navAriaLabel} className={styles.languageWrapper}>
       <ul role="list" className={styles.languages}>
         {favLanguages
-          .sort((a, b) =>
-            translatedLabel(a, langs).localeCompare(translatedLabel(b, langs)),
+          .sort(
+            (a, b) =>
+              translatedLabel(a, langs)?.localeCompare(
+                translatedLabel(b, langs),
+              ),
           )
           .map(language => {
             return (

--- a/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
+++ b/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
@@ -6,10 +6,7 @@ import { Language, TopicIds } from "common/types/types";
 import { getLanguagePath } from "common/utils/router.utils";
 import { FC } from "react";
 import { Link, useLocation } from "react-router-dom";
-import {
-  filterFavoriteLanguages,
-  translatedLabel,
-} from "../../utils/language.utils";
+import { sanitizeLanguages, translatedLabel } from "../../utils/language.utils";
 import { useL10n, useL10ns } from "../../hooks/useL10n";
 import styles from "./LanguageFavorites.module.scss";
 
@@ -39,7 +36,7 @@ export const LanguageFavorites: FC<LanguageFavoritesProps> = ({
 
   const navAriaLabel = useL10n("favoriteLanguagesAriaLabel");
 
-  const filteredFavLanguages = filterFavoriteLanguages(
+  const sanitizedFavLanguages = sanitizeLanguages(
     favLanguages,
     languagesFromDB,
   );
@@ -47,7 +44,7 @@ export const LanguageFavorites: FC<LanguageFavoritesProps> = ({
   return (
     <nav aria-label={navAriaLabel} className={styles.languageWrapper}>
       <ul role="list" className={styles.languages}>
-        {filteredFavLanguages
+        {sanitizedFavLanguages
           .sort(
             (a, b) =>
               translatedLabel(a, langs)?.localeCompare(

--- a/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
+++ b/h5p-bildetema/src/components/LanguageFavorites/LanguageFavorites.tsx
@@ -6,7 +6,10 @@ import { Language, TopicIds } from "common/types/types";
 import { getLanguagePath } from "common/utils/router.utils";
 import { FC } from "react";
 import { Link, useLocation } from "react-router-dom";
-import { translatedLabel } from "../../utils/language.utils";
+import {
+  filterFavoriteLanguages,
+  translatedLabel,
+} from "../../utils/language.utils";
 import { useL10n, useL10ns } from "../../hooks/useL10n";
 import styles from "./LanguageFavorites.module.scss";
 
@@ -19,7 +22,8 @@ export const LanguageFavorites: FC<LanguageFavoritesProps> = ({
   favLanguages,
   topicIds,
 }) => {
-  const { topics: topicsFromDB } = useDBContext() || {};
+  const { topics: topicsFromDB, languages: languagesFromDB } =
+    useDBContext() || {};
   const languageKeys = languagesConst.map(
     lang => `lang_${lang}`,
   ) as Array<LanguageCodeString>;
@@ -35,10 +39,15 @@ export const LanguageFavorites: FC<LanguageFavoritesProps> = ({
 
   const navAriaLabel = useL10n("favoriteLanguagesAriaLabel");
 
+  const filteredFavLanguages = filterFavoriteLanguages(
+    favLanguages,
+    languagesFromDB,
+  );
+
   return (
     <nav aria-label={navAriaLabel} className={styles.languageWrapper}>
       <ul role="list" className={styles.languages}>
-        {favLanguages
+        {filteredFavLanguages
           .sort(
             (a, b) =>
               translatedLabel(a, langs)?.localeCompare(

--- a/h5p-bildetema/src/utils/language.utils.ts
+++ b/h5p-bildetema/src/utils/language.utils.ts
@@ -10,7 +10,7 @@ export const translatedLabel = (
 };
 
 /**
- * Filter out languages that are not in the database.
+ * Filter out languages that are not in the database or the original list of languages.
  * This is to avoid errors when the database is updated.
  * @param languages - languages to sanitize
  * @param languagesFromDB - languages from the database
@@ -19,9 +19,9 @@ export const sanitizeLanguages = (
   languages: Language[],
   languagesFromDB: Language[] | undefined,
 ): Language[] => {
-  return languages
-    .filter(language => languagesOriginal?.[language.code])
-    .filter(
-      language => languagesFromDB?.find(lang => lang.code === language.code),
-    );
+  return languages.filter(
+    language =>
+      languagesOriginal?.[language.code] &&
+      languagesFromDB?.find(lang => lang.code === language.code),
+  );
 };

--- a/h5p-bildetema/src/utils/language.utils.ts
+++ b/h5p-bildetema/src/utils/language.utils.ts
@@ -1,3 +1,4 @@
+import { languagesOriginal } from "common/constants/languages";
 import { LanguageCodeString } from "common/types/LanguageCode";
 import { Language } from "common/types/types";
 
@@ -6,4 +7,19 @@ export const translatedLabel = (
   translations: Record<LanguageCodeString, string>,
 ): string => {
   return translations[`lang_${language.code}`];
+};
+
+/**
+ * Filter out languages that are not in the database.
+ * This is to avoid errors when the database is updated.
+ */
+export const filterFavoriteLanguages = (
+  favoriteLanguages: Language[],
+  languagesFromDB: Language[] | undefined,
+): Language[] => {
+  return favoriteLanguages
+    .filter(language => languagesOriginal?.[language.code])
+    .filter(
+      language => languagesFromDB?.find(lang => lang.code === language.code),
+    );
 };

--- a/h5p-bildetema/src/utils/language.utils.ts
+++ b/h5p-bildetema/src/utils/language.utils.ts
@@ -12,12 +12,14 @@ export const translatedLabel = (
 /**
  * Filter out languages that are not in the database.
  * This is to avoid errors when the database is updated.
+ * @param languages - languages to sanitize
+ * @param languagesFromDB - languages from the database
  */
-export const filterFavoriteLanguages = (
-  favoriteLanguages: Language[],
+export const sanitizeLanguages = (
+  languages: Language[],
   languagesFromDB: Language[] | undefined,
 ): Language[] => {
-  return favoriteLanguages
+  return languages
     .filter(language => languagesOriginal?.[language.code])
     .filter(
       language => languagesFromDB?.find(lang => lang.code === language.code),


### PR DESCRIPTION
Fixes "TypeError: Cannot read properties of undefined (reading 'localeCompare')" when trying to compare a language in favLanguages that are not in the database anymore. Example: when we changed the Filipino language code the old code could still be saved for some users - resulting in this TypeError.

It also ensures that no "old" languages will be shown for the user, and that the userData.favoriteLanguages will not store those languages anymore.