### PR TITLE
fix: add missing fields in topic image semantics

### DIFF
--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 82,
+  "patchVersion": 83,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/semantics.json
+++ b/h5p-bildetema-words-topic-image/semantics.json
@@ -95,9 +95,27 @@
               "type": "text"
             },
             {
-              "label": "Label",
-              "name": "label",
-              "type": "text"
+              "label": "Labels",
+              "name": "labels",
+              "type": "list",
+              "entity": "Label",
+              "field": {
+                "label": "Label",
+                "name": "label",
+                "type": "group",
+                "fields": [
+                  {
+                    "label": "Label",
+                    "name": "label",
+                    "type": "text"
+                  },
+                  {
+                    "label": "Article",
+                    "name": "article",
+                    "type": "text"
+                  }
+                ]
+              }
             },
             {
               "label": "Images",

--- a/h5p-bildetema-words-topic-image/semantics.json.d.ts
+++ b/h5p-bildetema-words-topic-image/semantics.json.d.ts
@@ -95,9 +95,27 @@ declare const $defaultExport: [
 							type: "text"
 						},
 						{
-							label: "Label",
-							name: "label",
-							type: "text"
+							label: "Labels",
+							name: "labels",
+							type: "list",
+							entity: "Label",
+							field: {
+								label: "Label",
+								name: "label",
+								type: "group",
+								fields: [
+									{
+										label: "Label",
+										name: "label",
+										type: "text"
+									},
+									{
+										label: "Article",
+										name: "article",
+										type: "text"
+									}
+								]
+							}
 						},
 						{
 							label: "Images",


### PR DESCRIPTION
Fixes TypeError when editing Topic Images in Wordpress. Word.labels was not stored since semantics didn't have updated field values for it.

If new Topic Images are created now, words will only have `id` and `images` and no `label` or `labels`. This means we have to add a check for this in `Editor.tsx` or `extractWordLabel` since these words will not have `label` or `labels` until they are updated in the useEffect of `Editor.tsx `. PR that can fix this in `extractWordLabel` https://github.com/Tietoevry-Create/h5p-bildetema/pull/1157