### PR TITLE
fix: only render words-grid-view when needed

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 193,
+  "patchVersion": 194,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 194,
+  "patchVersion": 195,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Words/Words.tsx
+++ b/h5p-bildetema/src/components/Words/Words.tsx
@@ -59,7 +59,6 @@ export const Words: FC<WordsProps> = ({
   const l10n = useContext(L10nContext);
   const { topics } = useDBContext() || {};
   const onlyTopicImage = useMemo(() => {
-    if (!isTopicImageView) return false;
     if (topic?.subTopicId) {
       return topics
         ?.find(t => t.id === topic?.topicId)
@@ -148,6 +147,11 @@ export const Words: FC<WordsProps> = ({
           setTopicImageView(false);
         }
 
+        // If onlyTopicImage is true, and a Topic Image exist, we don't need to render the grid view
+        if (currentTopicHasTopicImage && onlyTopicImage) {
+          return;
+        }
+
         const gridView = H5P.newRunnable(
           {
             library: getLibraryName(gridViewLibrary as H5PLibrary),
@@ -209,15 +213,11 @@ export const Words: FC<WordsProps> = ({
       )}
       <div
         ref={topicViewRef}
-        className={
-          !showTopicImageView && !onlyTopicImage ? styles.displayNone : ""
-        }
+        className={!showTopicImageView ? styles.displayNone : ""}
       />
       <div
         ref={gridViewRef}
-        className={
-          showTopicImageView || onlyTopicImage ? styles.displayNone : ""
-        }
+        className={showTopicImageView ? styles.displayNone : ""}
       />
     </>
   );

--- a/h5p-bildetema/src/components/Words/Words.tsx
+++ b/h5p-bildetema/src/components/Words/Words.tsx
@@ -65,7 +65,7 @@ export const Words: FC<WordsProps> = ({
         ?.subTopics.find(s => s.id === topic?.subTopicId)?.onlyTopicImage;
     }
     return topics?.find(t => t.id === topic?.topicId)?.onlyTopicImage;
-  }, [topic?.subTopicId, topic?.topicId, topics, isTopicImageView]);
+  }, [topic?.subTopicId, topic?.topicId, topics]);
 
   useEffect(() => {
     toggleShowTopicImageView(showTopicImageView);


### PR DESCRIPTION
Currently the grid is always rendered even though `onlyTopicImage` is set to true. This PR ensures that is it not rendered when it doesn't have to be.

The PR is difficult to test since `H5PAllContents` in `setViewInstances` does not work in localhost (getting all the topic images created in Wordpress), and no topic images will therefore be shown. But to explain the code: 

In order to get the actual value of the topic's `onlyTopicImage` property initially in `setViewInstances`, the `if (!isTopicImageView) return false;` in the `onlyTopicImage` useMemo needed to be removed. Then we could check `onlyTopicImage` to know if grid view should be rendered. The display class then only need to be set based on the value of `showTopicImageView`.