### PR TITLE
chore: install h5p-types v5.1.0

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "core-js": "^3.32.2",
-    "h5p-types": "^4.0.1",
+    "h5p-types": "^5.1.0",
     "h5p-utils": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/common/utils/library/library.utils.ts
+++ b/common/utils/library/library.utils.ts
@@ -1,9 +1,9 @@
-import { Library } from "h5p-types";
+import { H5PLibrary } from "h5p-types";
 
 export const getLibraryName = ({
   machineName,
   majorVersion,
   minorVersion,
-}: Library): string => {
+}: H5PLibrary): string => {
   return `${machineName} ${majorVersion}.${minorVersion}`;
 };

--- a/h5p-bildetema-words-topic-image/src/h5p/H5PWrapper.tsx
+++ b/h5p-bildetema-words-topic-image/src/h5p/H5PWrapper.tsx
@@ -1,7 +1,7 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { LanguageCode } from "common/types/LanguageCode";
 import type { TopicImageHotspot } from "common/types/TopicImageHotspot";
-import type { IH5PContentType, Image } from "h5p-types";
+import type { IH5PContentType, H5PImage } from "h5p-types";
 import { H5P, H5PContentType } from "h5p-utils";
 import { Root, createRoot } from "react-dom/client";
 import { ContentIdContext, H5PContext, L10nContext } from "use-h5p";
@@ -9,7 +9,7 @@ import { App } from "../App";
 import type { TranslationKey } from "../types/TranslationKey";
 
 export type Params = {
-  topicImage: Image;
+  topicImage: H5PImage;
   hotspots: Array<TopicImageHotspot>;
   selectedTopic: {
     topicId: string;

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
       "version": "1.0.0",
       "dependencies": {
         "core-js": "^3.32.2",
-        "h5p-types": "^4.0.1",
+        "h5p-types": "^5.1.0",
         "h5p-utils": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -5911,9 +5911,9 @@
       }
     },
     "node_modules/@types/jquery": {
-      "version": "3.5.19",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.19.tgz",
-      "integrity": "sha512-KFbmk+dXfphHGuVCmlopgcNRCegN/21mkeoD4BzuJhVH0SJW3Uo2mLuAwb6oqTNV79EsRp6J7yC1BbKymjpx/g==",
+      "version": "3.5.29",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.29.tgz",
+      "integrity": "sha512-oXQQC9X9MOPRrMhPHHOsXqeQDnWeCDT3PelUIg/Oy8FAbzSZtFHRjc7IpbfFVmpLtJ+UOoywpRsuO5Jxjybyeg==",
       "dependencies": {
         "@types/sizzle": "*"
       }
@@ -11123,11 +11123,11 @@
       "link": true
     },
     "node_modules/h5p-types": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-4.0.1.tgz",
-      "integrity": "sha512-pXORTv1Jv4+q8oHMhHUSvb42PlM1dkRLkACY6Kt039zKmB+zy03Rl3Z6bWHA+hZDFzH4CZvw4A8zcgrppBeKUg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/h5p-types/-/h5p-types-5.1.0.tgz",
+      "integrity": "sha512-YSuG6wMfuY5R6RTJP3RkbphMiNOxv4PeIx57GQ3zy6NwYnHSanMxySPebj+dho7G23eOuqlpZ1W94n//wMJSXA==",
       "dependencies": {
-        "@types/jquery": "^3.5.19",
+        "@types/jquery": "^3.5.29",
         "type-fest": "^4.3.1"
       },
       "peerDependencies": {


### PR DESCRIPTION
This version does not bring anything new to the table and everything _should_ work as before.

The reason for updating is mostly to see that the new version does not break anything in Bildetema (thus probably not breaking anything anywhere else either).