### PR TITLE
fix: search result translation label

### DIFF
--- a/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.module.scss
@@ -6,7 +6,7 @@
   align-items: center;
   position: relative;
   background: $white;
-  border: 2px solid $dark-beige;
+  border: 1.5px solid $dark-beige;
 }
 
 .image_container {
@@ -25,6 +25,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding: 0.5rem 0;
 }
 .translation {
   display: flex;
@@ -35,6 +36,8 @@
 .translationLang {
   color: #4d4d4d;
   font-style: italic;
+  font-size: $font-size-16;
+  line-height: 1;
 }
 
 .visuallyHidden {

--- a/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.tsx
@@ -111,12 +111,14 @@ export const MultiLanguageWord = ({
             // eslint-disable-next-line react/no-array-index-key
             key={`${translation.lang.code}-${index}`}
           >
-            <span className={styles.translationLang}>
-              {translatedLabel(
-                translation.lang.code,
-                translations,
-              ).toUpperCase()}
-            </span>
+            {searchResult.translations.length > 1 && (
+              <span className={styles.translationLang}>
+                {translatedLabel(
+                  translation.lang.code,
+                  translations,
+                ).toUpperCase()}
+              </span>
+            )}
             <Audio
               label={toSingleLabel(translation.labels, false)}
               lang={lang}

--- a/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.module.scss
@@ -7,7 +7,7 @@
   align-items: center;
   position: relative;
   background: $white;
-  border: 2px solid $dark-beige;
+  border: 1.5px solid $dark-beige;
 }
 
 .bookmarkButton {
@@ -52,6 +52,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
+  padding: 0.5rem 0;
 }
 .translation {
   display: flex;
@@ -62,6 +63,8 @@
 .translationLang {
   color: #4d4d4d;
   font-style: italic;
+  font-size: $font-size-16;
+  line-height: 1;
 }
 
 .visuallyHidden {

--- a/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.tsx
@@ -124,12 +124,14 @@ export const SearchResultCard = ({
             // eslint-disable-next-line react/no-array-index-key
             key={`${translation.lang.code}-${index}`}
           >
-            <span className={styles.translationLang}>
-              {translatedLabel(
-                translation.lang.code,
-                translations,
-              ).toUpperCase()}
-            </span>
+            {searchResult.translations.length > 1 && (
+              <span className={styles.translationLang}>
+                {translatedLabel(
+                  translation.lang.code,
+                  translations,
+                ).toUpperCase()}
+              </span>
+            )}
             <Audio
               label={toSingleLabel(translation.labels)}
               lang={lang}


### PR DESCRIPTION
- Only shows the translation label when one language is displayed in search results and collections
- Makes the translation label font-size smaller
- Makes a bit more padding around the translations