### PR TITLE
fix: search page on mobile

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 211,
+  "patchVersion": 212,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/Button/Button.module.scss
+++ b/h5p-bildetema/src/components/Button/Button.module.scss
@@ -38,6 +38,23 @@
   text-decoration: underline;
 }
 
+.filter {
+  color: black;
+  background-color: $white;
+  border: 2px solid $dark-beige;
+  gap: $spacing--8;
+  padding: 0.5785rem 1.25rem;
+  width: auto;
+
+  span {
+    line-height: 2rem;
+  }
+
+  svg {
+    flex: 0 0 auto; // prevent svg from shrinking
+  }
+}
+
 .disabled {
   cursor: default;
   opacity: 0.4;

--- a/h5p-bildetema/src/components/Button/Button.module.scss
+++ b/h5p-bildetema/src/components/Button/Button.module.scss
@@ -42,6 +42,7 @@
   color: black;
   background-color: $white;
   border: 2px solid $dark-beige;
+  box-sizing: border-box;
   gap: $spacing--8;
   padding: 0.5785rem 1.25rem;
   width: auto;

--- a/h5p-bildetema/src/components/Button/Button.tsx
+++ b/h5p-bildetema/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import styles from "./Button.module.scss";
 
-type variants = "primary" | "secondary" | "underline";
+type variants = "primary" | "secondary" | "underline" | "filter";
 
 export interface ButtonProps extends React.ComponentProps<"button"> {
   children: React.ReactNode;

--- a/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.module.scss
@@ -88,7 +88,15 @@
 
 .closeButton {
   all: unset;
+  background-color: $white;
+  border: none;
+  border-radius: 50%;
   cursor: pointer;
+  padding: 0.5rem;
+
+  &:hover {
+    background-color: $beige;
+  }
 }
 
 .amount {

--- a/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.module.scss
@@ -101,6 +101,7 @@
 
 .amount {
   display: flex;
+  flex: 0 0 auto; // prevent item from shrinking
   align-items: center;
   justify-content: center;
   color: $white;
@@ -113,4 +114,10 @@
 
 .label {
   font-weight: bold;
+}
+
+.buttonLabel {
+  font-weight: bold;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.tsx
@@ -37,10 +37,10 @@ const SearchFilterDialog = ({
 
   return (
     <>
-      <Button variant="secondary" onClick={() => setIsOpen(true)}>
+      <Button variant="filter" onClick={() => setIsOpen(true)}>
         <Filter />
         {/* TODO: translate */}
-        <span className={styles.label}>Filtrer etter tema</span>
+        <span className={styles.buttonLabel}>Filtrer etter tema</span>
         {checkedTopicsAmount > 0 && (
           <div className={styles.amount}>{checkedTopicsAmount}</div>
         )}

--- a/h5p-bildetema/src/components/SearchPage/SearchInput/SearchInput.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchInput/SearchInput.module.scss
@@ -1,8 +1,9 @@
 @use "common/abstracts" as *;
 
 .searchInputWrapper {
+  flex-grow: 1;
+  min-width: 16rem;
   position: relative;
-  width: 100%;
 }
 
 // HACK use id to override default h5p styles

--- a/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.module.scss
@@ -21,6 +21,7 @@
 
   @include breakpoint-min($x-small) {
     flex-direction: row;
+    flex-wrap: wrap;
   }
 }
 

--- a/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.module.scss
@@ -22,17 +22,20 @@
   @include breakpoint-min($x-small) {
     flex-direction: row;
     flex-wrap: wrap;
+    justify-content: center;
   }
 }
 
 .buttonWrapper {
   display: flex;
-  width: 100%;
-  justify-content: center;
-  gap: 0.5rem;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 100%;
 
   @include breakpoint-min($x-small) {
-    gap: 1rem;
+    flex-direction: row;
+    flex-wrap: wrap;
+    justify-content: center;
   }
 }
 

--- a/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.module.scss
@@ -28,14 +28,14 @@
 
 .buttonWrapper {
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
+  flex-wrap: wrap;
   gap: 1rem;
+  justify-content: center;
   max-width: 100%;
 
-  @include breakpoint-min($x-small) {
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
+  & > * {
+    max-width: 100%;
   }
 }
 

--- a/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
@@ -81,7 +81,9 @@ const SearchView = ({
             selectedOption={viewLanguage}
             variant="secondary"
             // TODO: translate
-            labelPrefix="Vis på flere språk"
+            labelPrefix={`${
+              viewLanguage == null ? "Vis på flere språk" : "Vis på"
+            }`}
             withSelectedIcon
           />
         </div>

--- a/h5p-bildetema/src/components/Select/Select.module.scss
+++ b/h5p-bildetema/src/components/Select/Select.module.scss
@@ -65,10 +65,10 @@
 
 .option {
   font-family: sans-serif;
+  font-size: $font-size-16;
+  line-height: 1.4;
   white-space: nowrap;
-
   padding: 0.5rem 1rem;
-
   cursor: default;
 
   &:hover,
@@ -94,4 +94,8 @@
 .icon {
   position: absolute;
   left: 0.75rem;
+
+  svg {
+    vertical-align: middle;
+  }
 }

--- a/h5p-bildetema/src/components/Select/Select.module.scss
+++ b/h5p-bildetema/src/components/Select/Select.module.scss
@@ -22,6 +22,10 @@
   & b {
     font-weight: bold;
   }
+
+  svg {
+    overflow: visible;
+  }
 }
 
 .secondary {
@@ -98,4 +102,9 @@
   svg {
     vertical-align: middle;
   }
+}
+
+.buttonText {
+  overflow: hidden;
+  text-overflow: ellipsis;
 }

--- a/h5p-bildetema/src/components/Select/Select.tsx
+++ b/h5p-bildetema/src/components/Select/Select.tsx
@@ -34,7 +34,7 @@ const Select = <T extends Option>({
 }: SelectProps<T>): JSX.Element => {
   const labelWithPrefix = (
     <>
-      {labelPrefix} <b>{selectedOption?.label}</b>
+      {labelPrefix} <b className={styles.buttonText}>{selectedOption?.label}</b>
     </>
   );
   const labelWithPrefixOnly = <b>{labelPrefix}</b>;

--- a/h5p-bildetema/src/components/Select/Select.tsx
+++ b/h5p-bildetema/src/components/Select/Select.tsx
@@ -32,18 +32,25 @@ const Select = <T extends Option>({
   fixed,
   withSelectedIcon,
 }: SelectProps<T>): JSX.Element => {
-  const labelWithPrefix = (
-    <>
-      {labelPrefix} <b className={styles.buttonText}>{selectedOption?.label}</b>
-    </>
-  );
-  const labelWithPrefixOnly = <b>{labelPrefix}</b>;
+  const getLabel = (label: string | undefined): string | JSX.Element => {
+    switch (label) {
+      case undefined:
+        if (labelPrefix) {
+          return <b>{labelPrefix}</b>;
+        }
+        return placeholder || "";
+      default:
+        if (labelPrefix) {
+          return (
+            <>
+              {labelPrefix} <b className={styles.buttonText}>{label}</b>
+            </>
+          );
+        }
+        return label;
+    }
+  };
 
-  const label = labelPrefix
-    ? selectedOption === null
-      ? labelWithPrefixOnly
-      : labelWithPrefix
-    : selectedOption?.label;
   return (
     <Listbox
       value={selectedOption}
@@ -58,7 +65,7 @@ const Select = <T extends Option>({
           <Listbox.Button
             className={`${styles.selectButton} ${styles[variant]}`}
           >
-            {label === undefined ? placeholder : label}
+            {getLabel(selectedOption?.label)}
 
             <LanguageMenuArrowIcon
               transform={open ? "scale(1) rotate(180)" : "scale(1)"}

--- a/h5p-bildetema/src/components/Select/Select.tsx
+++ b/h5p-bildetema/src/components/Select/Select.tsx
@@ -32,13 +32,18 @@ const Select = <T extends Option>({
   fixed,
   withSelectedIcon,
 }: SelectProps<T>): JSX.Element => {
-  const label = labelPrefix ? (
+  const labelWithPrefix = (
     <>
       {labelPrefix} <b>{selectedOption?.label}</b>
     </>
-  ) : (
-    selectedOption?.label
   );
+  const labelWithPrefixOnly = <b>{labelPrefix}</b>;
+
+  const label = labelPrefix
+    ? selectedOption === null
+      ? labelWithPrefixOnly
+      : labelWithPrefix
+    : selectedOption?.label;
   return (
     <Listbox
       value={selectedOption}


### PR DESCRIPTION
- Make the prefix for the view language select shorter when a language is selected
- Makes sure the filter button and view language select wraps under each other on small devices
- Makes sure the input field has a minimum width
- Handle overflow on buttons and selects if there are really long labels for some translations
- Makes the options for the selects a litte bit bigger
- Adds hover styling to filter dialog close button