### PR TITLE
Feat/add control buttons to collection page

### DIFF
--- a/common/utils/word.utils.ts
+++ b/common/utils/word.utils.ts
@@ -60,6 +60,19 @@ export const newWordsIncludesArticles = (
   });
 };
 
+export const searchResultsIncludesArticles = (
+  words: SearchResult[],
+  langCode: LanguageCode,
+): boolean => {
+  return words.some(word => {
+    const isTopicWord = word.id.includes("T");
+    if (isTopicWord) return false;
+    return word.translations
+      .find(x => x.lang.code === langCode)
+      ?.labels.some(el => el.article);
+  });
+};
+
 const findTranslationsForWord = (
   word: Word,
   topic: Topic,

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 89,
+  "patchVersion": 90,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/library.json.d.ts
+++ b/h5p-bildetema-words-grid-view/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "H5P Bildetema Words Grid View";
 export const machineName : "H5P.BildetemaWordsGridView";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 89;
+export const patchVersion : 90;
 export const runnable : 1;
 export const preloadedJs : [
 	{

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 93,
+  "patchVersion": 94,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 213,
+  "patchVersion": 214,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/App/App.tsx
+++ b/h5p-bildetema/src/components/App/App.tsx
@@ -5,6 +5,7 @@ import { getNewData } from "common/utils/data.utils";
 import { FC } from "react";
 import { Bildetema } from "../Bildetema/Bildetema";
 import "common/styles/SwiperOverride.scss";
+import { SearchParamProvider } from "../../context/SearchParamContext";
 
 type appProps = {
   defaultLanguages: string[];
@@ -21,10 +22,12 @@ export const App: FC<appProps> = ({ defaultLanguages, backendUrl }) => {
   return (
     <BackendUrlContext.Provider value={baseBackendurl}>
       <NewDBContext.Provider value={newData}>
-        <Bildetema
-          defaultLanguages={defaultLanguages}
-          isLoadingData={isLoading}
-        />
+        <SearchParamProvider>
+          <Bildetema
+            defaultLanguages={defaultLanguages}
+            isLoadingData={isLoading}
+          />
+        </SearchParamProvider>
       </NewDBContext.Provider>
     </BackendUrlContext.Provider>
   );

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -168,11 +168,11 @@ export const Bildetema: FC<BildetemaProps> = ({
             <Route path={`${STATIC_PATH.SEARCH}`} element={<SearchPage />} />
             <Route
               path={`${STATIC_PATH.COLLECTIONS}`}
-              element={<CollectionsController />}
+              element={<CollectionsController rtl={directionRtl} />}
             />
             <Route
               path={`${STATIC_PATH.COLLECTIONS}/:collection`}
-              element={<CollectionsController />}
+              element={<CollectionsController rtl={directionRtl} />}
             />
           </>
         )}

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -3,7 +3,7 @@ import { LanguageCode } from "common/types/LanguageCode";
 import { CurrentTopics } from "common/types/types";
 import { labelToUrlComponent } from "common/utils/string.utils";
 import { FC, ReactPortal } from "react";
-import { Link, useLocation } from "react-router-dom";
+import { Link } from "react-router-dom";
 import { useNewDBContext } from "common/hooks/useNewDBContext";
 import useBreadcrumbs from "use-react-router-breadcrumbs";
 import { useL10n } from "../../hooks/useL10n";
@@ -45,7 +45,6 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
   const homeLabel = useL10n("breadcrumbsHome");
   const routes = [{ path: `/${currentLanguageCode}`, breadcrumb: topicLabel }];
   const routeBreadCrumbs = useBreadcrumbs(routes);
-  const { search } = useLocation();
 
   const breadCrumbsToRender =
     breadCrumbs ??
@@ -85,7 +84,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
       })();
 
       return {
-        path: `${key}${search}`,
+        path: `${key}`,
         label,
       };
     });

--- a/h5p-bildetema/src/components/CollectionsController/CollectionController.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionController.module.scss
@@ -13,8 +13,5 @@
   margin-bottom: 2rem;
 }
 .menuWrapper {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
   padding: 2rem 0rem;
 }

--- a/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
@@ -1,15 +1,58 @@
-import { useParams } from "react-router-dom";
-import { useMemo } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
+import { useMemo, useState } from "react";
 import { STATIC_PATH } from "common/constants/paths";
+import { searchResultsIncludesArticles } from "common/utils/word.utils";
 import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
-import { Breadcrumbs } from "../Breadcrumbs/Breadcrumbs";
 import styles from "./CollectionController.module.scss";
 import CollectionPage from "./CollectionPage/CollectionPage";
 import CollectionsPage from "./CollectionsPage/CollectionsPage";
+import { SubHeader } from "../SubHeader/SubHeader";
+import { SearchParameters } from "../../enums/SearchParameters";
+import { useToggleSearchParam } from "../../hooks/useToggleSearchParam";
+import { useSelectedWords } from "../../hooks/useSelectedWords";
 
-const CollectionController = (): JSX.Element => {
+const defaultShowWrittenWords = true;
+const defaultShowArticles = false;
+
+type CollectionControllerProps = {
+  rtl: boolean;
+};
+
+const CollectionController = ({
+  rtl,
+}: CollectionControllerProps): JSX.Element => {
   const { collection } = useParams();
   const langCode = useCurrentLanguageCode();
+  const [searchParams] = useSearchParams();
+  const words = useSelectedWords();
+
+  const [showWrittenWords, setShowWrittenWords] = useState(
+    searchParams.get(SearchParameters.wordsVisible) !== null
+      ? searchParams.get(SearchParameters.wordsVisible) === "true"
+      : defaultShowWrittenWords,
+  );
+
+  const [showArticles, setShowArticles] = useState(
+    searchParams.get(SearchParameters.articlesVisible) !== null
+      ? searchParams.get(SearchParameters.articlesVisible) === "true"
+      : defaultShowArticles,
+  );
+
+  const handleShowArticlesChange = useToggleSearchParam(
+    SearchParameters.articlesVisible,
+    defaultShowArticles,
+    setShowArticles,
+  );
+
+  const handleShowWrittenWordsChange = useToggleSearchParam(
+    SearchParameters.wordsVisible,
+    defaultShowWrittenWords,
+    setShowWrittenWords,
+  );
+
+  const showArticlesToggle = useMemo(() => {
+    return searchResultsIncludesArticles(words, langCode);
+  }, [langCode, words]);
 
   const breadCrumbs = useMemo(() => {
     const crumbs = [
@@ -36,13 +79,28 @@ const CollectionController = (): JSX.Element => {
     if (!collection) {
       return <CollectionsPage />;
     }
-    return <CollectionPage collectionTitle={collection} />;
+    return (
+      <CollectionPage
+        collectionTitle={collection}
+        showWrittenWords={showWrittenWords}
+        showArticles={showArticles}
+      />
+    );
   };
 
   return (
     <div className={`${styles.CollectionController} ${styles.mainSize}`}>
       <div className={styles.menuWrapper}>
-        <Breadcrumbs currentLanguageCode={langCode} breadCrumbs={breadCrumbs} />
+        <SubHeader
+          breadCrumbs={breadCrumbs}
+          isWordView={!!collection}
+          showWrittenWords={showWrittenWords}
+          rtl={rtl}
+          showArticlesToggle={showArticlesToggle}
+          showArticles={showArticles}
+          onShowWrittenWordsChange={handleShowWrittenWordsChange}
+          onShowArticlesChange={handleShowArticlesChange}
+        />
       </div>
       <div className={styles.contentWrapper}>{currentPage()}</div>
     </div>

--- a/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
@@ -1,5 +1,5 @@
-import { useParams, useSearchParams } from "react-router-dom";
-import { useMemo, useState } from "react";
+import { useParams } from "react-router-dom";
+import { useMemo } from "react";
 import { STATIC_PATH } from "common/constants/paths";
 import { searchResultsIncludesArticles } from "common/utils/word.utils";
 import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
@@ -7,12 +7,8 @@ import styles from "./CollectionController.module.scss";
 import CollectionPage from "./CollectionPage/CollectionPage";
 import CollectionsPage from "./CollectionsPage/CollectionsPage";
 import { SubHeader } from "../SubHeader/SubHeader";
-import { SearchParameters } from "../../enums/SearchParameters";
-import { useToggleSearchParam } from "../../hooks/useToggleSearchParam";
 import { useSelectedWords } from "../../hooks/useSelectedWords";
-
-const defaultShowWrittenWords = true;
-const defaultShowArticles = false;
+import { useSearchParamContext } from "../../hooks/useSearchParamContext";
 
 type CollectionControllerProps = {
   rtl: boolean;
@@ -23,32 +19,8 @@ const CollectionController = ({
 }: CollectionControllerProps): JSX.Element => {
   const { collection } = useParams();
   const langCode = useCurrentLanguageCode();
-  const [searchParams] = useSearchParams();
   const words = useSelectedWords();
-
-  const [showWrittenWords, setShowWrittenWords] = useState(
-    searchParams.get(SearchParameters.wordsVisible) !== null
-      ? searchParams.get(SearchParameters.wordsVisible) === "true"
-      : defaultShowWrittenWords,
-  );
-
-  const [showArticles, setShowArticles] = useState(
-    searchParams.get(SearchParameters.articlesVisible) !== null
-      ? searchParams.get(SearchParameters.articlesVisible) === "true"
-      : defaultShowArticles,
-  );
-
-  const handleShowArticlesChange = useToggleSearchParam(
-    SearchParameters.articlesVisible,
-    defaultShowArticles,
-    setShowArticles,
-  );
-
-  const handleShowWrittenWordsChange = useToggleSearchParam(
-    SearchParameters.wordsVisible,
-    defaultShowWrittenWords,
-    setShowWrittenWords,
-  );
+  const { showArticles, showWrittenWords } = useSearchParamContext();
 
   const showArticlesToggle = useMemo(() => {
     return searchResultsIncludesArticles(words, langCode);
@@ -57,7 +29,10 @@ const CollectionController = ({
   const breadCrumbs = useMemo(() => {
     const crumbs = [
       // TODO: translate
-      { label: "Home", path: `/${langCode}` },
+      {
+        label: "Home",
+        path: `/${langCode}`,
+      },
       {
         // TODO: translate
         label: "Mine samlinger",
@@ -94,12 +69,8 @@ const CollectionController = ({
         <SubHeader
           breadCrumbs={breadCrumbs}
           isWordView={!!collection}
-          showWrittenWords={showWrittenWords}
           rtl={rtl}
           showArticlesToggle={showArticlesToggle}
-          showArticles={showArticles}
-          onShowWrittenWordsChange={handleShowWrittenWordsChange}
-          onShowArticlesChange={handleShowArticlesChange}
         />
       </div>
       <div className={styles.contentWrapper}>{currentPage()}</div>

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
@@ -8,11 +8,17 @@ import { MultiLanguageWord } from "../MultiLanguageWord/MultiLanguageWord";
 
 type MyCollection = {
   collectionTitle: string;
+  showArticles: boolean;
+  showWrittenWords: boolean;
 };
 
-const CollectionPage = ({ collectionTitle }: MyCollection): JSX.Element => {
-  const words = useSelectedWords();
+const CollectionPage = ({
+  collectionTitle,
+  showWrittenWords,
+  showArticles,
+}: MyCollection): JSX.Element => {
   const { addCollection } = useMyCollections();
+  const words = useSelectedWords();
 
   useEffect(() => {
     if (collectionTitle === undefined) return;
@@ -34,7 +40,12 @@ const CollectionPage = ({ collectionTitle }: MyCollection): JSX.Element => {
   return (
     <div className={styles.words}>
       {words.map(word => (
-        <MultiLanguageWord searchResult={word} />
+        <MultiLanguageWord
+          key={word.id}
+          searchResult={word}
+          showWrittenWords={showWrittenWords}
+          showArticles={showArticles}
+        />
       ))}
     </div>
   );

--- a/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.tsx
@@ -17,10 +17,14 @@ import { translatedLabel } from "../../../utils/language.utils";
 
 type SearchResultCardProps = {
   searchResult: SearchResult;
+  showArticles: boolean;
+  showWrittenWords: boolean;
 };
 
 export const MultiLanguageWord = ({
   searchResult,
+  showArticles,
+  showWrittenWords,
 }: SearchResultCardProps): JSX.Element => {
   const { images } = searchResult;
 
@@ -120,7 +124,11 @@ export const MultiLanguageWord = ({
               </span>
             )}
             <Audio
-              label={toSingleLabel(translation.labels, false)}
+              label={
+                showWrittenWords
+                  ? toSingleLabel(translation.labels, showArticles)
+                  : ""
+              }
               lang={lang}
               playAudioLabel={playAudioLabel}
               stopAudioLabel={stopAudioLabel}

--- a/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
+++ b/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
@@ -5,7 +5,6 @@ import { useL10ns } from "../../hooks/useL10n";
 import { LanguageMenuArrowIcon, PrintIcon } from "../Icons/Icons";
 import { PrintWords } from "../PrintWords/PrintWords";
 import styles from "./PrintButton.module.scss";
-import { useCurrentWords } from "../../hooks/useCurrentWords";
 
 type PrintProps = {
   showWrittenWords: boolean;
@@ -25,7 +24,6 @@ export const PrintButton: FC<PrintProps> = ({
   const [viewPrintDropDown, setViewPrintDropDown] = useState(false);
   const [renderPrintWords, setRenderPrintWords] = useState(false);
   const [isActive, setIsActive] = useState(false);
-  const currentWords = useCurrentWords();
 
   const handleOnClickOutside = (): void => {
     setViewPrintDropDown(false);
@@ -144,7 +142,6 @@ export const PrintButton: FC<PrintProps> = ({
             showWrittenWords={showWrittenWords}
             imagesPrRow={imagesPrRow}
             showArticles={showArticles}
-            words={currentWords}
           />
         </div>
       )}

--- a/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
+++ b/h5p-bildetema/src/components/PrintButton/PrintButton.tsx
@@ -5,6 +5,7 @@ import { useL10ns } from "../../hooks/useL10n";
 import { LanguageMenuArrowIcon, PrintIcon } from "../Icons/Icons";
 import { PrintWords } from "../PrintWords/PrintWords";
 import styles from "./PrintButton.module.scss";
+import { useCurrentWords } from "../../hooks/useCurrentWords";
 
 type PrintProps = {
   showWrittenWords: boolean;
@@ -24,6 +25,7 @@ export const PrintButton: FC<PrintProps> = ({
   const [viewPrintDropDown, setViewPrintDropDown] = useState(false);
   const [renderPrintWords, setRenderPrintWords] = useState(false);
   const [isActive, setIsActive] = useState(false);
+  const currentWords = useCurrentWords();
 
   const handleOnClickOutside = (): void => {
     setViewPrintDropDown(false);
@@ -142,6 +144,7 @@ export const PrintButton: FC<PrintProps> = ({
             showWrittenWords={showWrittenWords}
             imagesPrRow={imagesPrRow}
             showArticles={showArticles}
+            words={currentWords}
           />
         </div>
       )}

--- a/h5p-bildetema/src/components/SubHeader/SubHeader.stories.tsx
+++ b/h5p-bildetema/src/components/SubHeader/SubHeader.stories.tsx
@@ -8,26 +8,17 @@ export default {
   title: "Components/Sub header",
   component: SubHeader,
   render: ({ isWordView, rtl }) => {
-    const [checked, setChecked] = useState(true);
-    const [articlesChecked, setArticlesChecked] = useState(true);
-    const [topicSize, setTopicsSize] = useState(TopicGridSizes.Big);
+    const [topicsSize, setTopicsSize] = useState(TopicGridSizes.Big);
+    const [showArticlesToggle] = useState(true);
 
     return (
       <SubHeader
-        currentTopics={{}}
+        topicsSize={topicsSize}
         setTopicsSize={setTopicsSize}
-        topicsSize={topicSize}
         isWordView={isWordView}
-        handleToggleChange={(value: boolean) => {
-          setChecked(value);
-        }}
-        toggleChecked={checked}
         showTopicImageView={false}
         rtl={rtl}
-        handleToggleArticles={(value: boolean): void => {
-          setArticlesChecked(value);
-        }}
-        articlesToggleChecked={articlesChecked}
+        showArticlesToggle={showArticlesToggle}
       />
     );
   },

--- a/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
+++ b/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
@@ -1,10 +1,7 @@
 import { LanguageCode } from "common/types/LanguageCode";
 import { CurrentTopics, TopicGridSizes } from "common/types/types";
-import { Dispatch, FC, SetStateAction, useMemo } from "react";
+import { Dispatch, FC, SetStateAction } from "react";
 import { useContentId } from "use-h5p";
-import { newWordsIncludesArticles } from "common/utils/word.utils";
-import { useNewDBContext } from "common/hooks/useNewDBContext";
-import { getNewWordsFromId } from "common/utils/data.utils";
 import { useL10ns } from "../../hooks/useL10n";
 import { Breadcrumbs } from "../Breadcrumbs/Breadcrumbs";
 import { PrintButton } from "../PrintButton/PrintButton";
@@ -16,83 +13,74 @@ import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
 export type SubHeaderProps = {
   topicsSize: TopicGridSizes;
   setTopicsSize: Dispatch<SetStateAction<TopicGridSizes>>;
-  isWordView: boolean;
-  toggleChecked: boolean;
-  handleToggleChange: (value: boolean) => void;
-  handleToggleArticles: (value: boolean) => void;
-  articlesToggleChecked: boolean;
+  currentTopics: CurrentTopics;
+  breadCrumbs?: {
+    label: string;
+    path: string;
+  }[];
   showTopicImageView: boolean;
   rtl: boolean;
-  currentTopics: CurrentTopics;
+  isWordView: boolean;
+  showArticlesToggle: boolean;
+  showWrittenWords: boolean;
+  showArticles: boolean;
+  onShowWrittenWordsChange: (value: boolean) => void;
+  onShowArticlesChange: (value: boolean) => void;
 };
 
 export const SubHeader: FC<SubHeaderProps> = ({
   topicsSize,
   setTopicsSize,
+  currentTopics,
   isWordView,
-  toggleChecked,
-  handleToggleChange,
+  showWrittenWords,
   showTopicImageView,
   rtl,
-  handleToggleArticles,
-  articlesToggleChecked,
-  currentTopics,
+  showArticles,
+  showArticlesToggle,
+  onShowWrittenWordsChange,
+  onShowArticlesChange,
+  breadCrumbs,
 }) => {
-  const { idToContent, idToWords } = useNewDBContext();
   const { showWrittenWordsLabel } = useL10ns("showWrittenWordsLabel");
   const { showArticlesLabel } = useL10ns("showArticlesLabel");
+  const currentLanguageCode = useCurrentLanguageCode();
 
   const contentId = useContentId();
 
-  const currentLanguageCode = useCurrentLanguageCode();
-
-  const showArticlesToggle = useMemo(() => {
-    const { topic, subTopic } = currentTopics;
-    if (subTopic) {
-      const words = getNewWordsFromId(subTopic.id, idToWords, idToContent);
-      return newWordsIncludesArticles(words, currentLanguageCode);
-    }
-    if (topic) {
-      const words = getNewWordsFromId(topic.id, idToWords, idToContent);
-      return newWordsIncludesArticles(words, currentLanguageCode);
-    }
-    return false;
-  }, [currentLanguageCode, currentTopics, idToContent, idToWords]);
-
-  const renderLeftMenu = (): JSX.Element => {
-    const element = isWordView ? (
-      <>
-        <Toggle
-          label={showWrittenWordsLabel}
-          checked={toggleChecked}
-          handleChange={handleToggleChange}
-          id={`toggle-${contentId}`}
-        />
-        {showArticlesToggle && (
-          <Toggle
-            label={showArticlesLabel}
-            checked={articlesToggleChecked}
-            handleChange={handleToggleArticles}
-            id={`toggle-articles-${contentId}`}
-          />
-        )}
-      </>
-    ) : (
-      <TopicSizeButtons topicsSize={topicsSize} setTopicsSize={setTopicsSize} />
-    );
-
+  const renderRightMenu = (): JSX.Element => {
     return (
-      <span className={styles.tools}>
-        {isWordView && (
-          <PrintButton
-            showWrittenWords={toggleChecked}
-            isWordView={isWordView}
-            showTopicImageView={showTopicImageView}
-            showArticles={articlesToggleChecked && showArticlesToggle}
+      <div className={styles.tools}>
+        {isWordView ? (
+          <>
+            <PrintButton
+              showWrittenWords={showWrittenWords}
+              isWordView={isWordView}
+              showTopicImageView={showTopicImageView}
+              showArticles={showArticles && showArticlesToggle}
+            />
+            <Toggle
+              label={showWrittenWordsLabel}
+              checked={showWrittenWords}
+              handleChange={onShowWrittenWordsChange}
+              id={`toggle-${contentId}`}
+            />
+            {showArticlesToggle && (
+              <Toggle
+                label={showArticlesLabel}
+                checked={showArticles}
+                handleChange={onShowArticlesChange}
+                id={`toggle-articles-${contentId}`}
+              />
+            )}
+          </>
+        ) : (
+          <TopicSizeButtons
+            topicsSize={topicsSize}
+            setTopicsSize={setTopicsSize}
           />
         )}
-        {element}
-      </span>
+      </div>
     );
   };
 
@@ -105,8 +93,9 @@ export const SubHeader: FC<SubHeaderProps> = ({
       <Breadcrumbs
         currentLanguageCode={currentLanguageCode as LanguageCode}
         currentTopics={currentTopics}
+        breadCrumbs={breadCrumbs}
       />
-      {renderLeftMenu()}
+      {renderRightMenu()}
     </div>
   );
 };

--- a/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
+++ b/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
@@ -1,6 +1,6 @@
 import { LanguageCode } from "common/types/LanguageCode";
 import { CurrentTopics, TopicGridSizes } from "common/types/types";
-import { Dispatch, FC, SetStateAction } from "react";
+import { Dispatch, FC, SetStateAction, useEffect } from "react";
 import { useContentId } from "use-h5p";
 import { useL10ns } from "../../hooks/useL10n";
 import { Breadcrumbs } from "../Breadcrumbs/Breadcrumbs";
@@ -9,6 +9,7 @@ import { Toggle } from "../Toggle/Toggle";
 import { TopicSizeButtons } from "../TopicSizeButtons/TopicSizeButtons";
 import styles from "./SubHeader.module.scss";
 import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
+import { useSearchParamContext } from "../../hooks/useSearchParamContext";
 
 export type SubHeaderProps = {
   topicsSize?: TopicGridSizes;
@@ -22,10 +23,6 @@ export type SubHeaderProps = {
   rtl: boolean;
   isWordView: boolean;
   showArticlesToggle: boolean;
-  showWrittenWords: boolean;
-  showArticles: boolean;
-  onShowWrittenWordsChange: (value: boolean) => void;
-  onShowArticlesChange: (value: boolean) => void;
 };
 
 export const SubHeader: FC<SubHeaderProps> = ({
@@ -33,20 +30,30 @@ export const SubHeader: FC<SubHeaderProps> = ({
   setTopicsSize,
   currentTopics,
   isWordView,
-  showWrittenWords,
   showTopicImageView = false,
   rtl,
-  showArticles,
   showArticlesToggle,
-  onShowWrittenWordsChange,
-  onShowArticlesChange,
   breadCrumbs,
 }) => {
   const { showWrittenWordsLabel } = useL10ns("showWrittenWordsLabel");
   const { showArticlesLabel } = useL10ns("showArticlesLabel");
   const currentLanguageCode = useCurrentLanguageCode();
 
+  const {
+    showArticles,
+    showWrittenWords,
+    handleShowArticlesChange,
+    handleShowWrittenWordsChange,
+    syncStateWithParams,
+  } = useSearchParamContext();
+
   const contentId = useContentId();
+
+  useEffect(() => {
+    if (isWordView) {
+      syncStateWithParams();
+    }
+  }, [isWordView, syncStateWithParams]);
 
   const showTopicSizeButtons =
     topicsSize !== undefined && setTopicsSize !== undefined;
@@ -65,14 +72,14 @@ export const SubHeader: FC<SubHeaderProps> = ({
             <Toggle
               label={showWrittenWordsLabel}
               checked={showWrittenWords}
-              handleChange={onShowWrittenWordsChange}
+              handleChange={handleShowWrittenWordsChange}
               id={`toggle-${contentId}`}
             />
             {showArticlesToggle && (
               <Toggle
                 label={showArticlesLabel}
                 checked={showArticles}
-                handleChange={onShowArticlesChange}
+                handleChange={handleShowArticlesChange}
                 id={`toggle-articles-${contentId}`}
               />
             )}

--- a/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
+++ b/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
@@ -11,14 +11,14 @@ import styles from "./SubHeader.module.scss";
 import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
 
 export type SubHeaderProps = {
-  topicsSize: TopicGridSizes;
-  setTopicsSize: Dispatch<SetStateAction<TopicGridSizes>>;
-  currentTopics: CurrentTopics;
+  topicsSize?: TopicGridSizes;
+  setTopicsSize?: Dispatch<SetStateAction<TopicGridSizes>>;
+  currentTopics?: CurrentTopics;
   breadCrumbs?: {
     label: string;
     path: string;
   }[];
-  showTopicImageView: boolean;
+  showTopicImageView?: boolean;
   rtl: boolean;
   isWordView: boolean;
   showArticlesToggle: boolean;
@@ -34,7 +34,7 @@ export const SubHeader: FC<SubHeaderProps> = ({
   currentTopics,
   isWordView,
   showWrittenWords,
-  showTopicImageView,
+  showTopicImageView = false,
   rtl,
   showArticles,
   showArticlesToggle,
@@ -47,6 +47,9 @@ export const SubHeader: FC<SubHeaderProps> = ({
   const currentLanguageCode = useCurrentLanguageCode();
 
   const contentId = useContentId();
+
+  const showTopicSizeButtons =
+    topicsSize !== undefined && setTopicsSize !== undefined;
 
   const renderRightMenu = (): JSX.Element => {
     return (
@@ -74,12 +77,14 @@ export const SubHeader: FC<SubHeaderProps> = ({
               />
             )}
           </>
-        ) : (
+        ) : null}
+
+        {showTopicSizeButtons && !isWordView ? (
           <TopicSizeButtons
             topicsSize={topicsSize}
             setTopicsSize={setTopicsSize}
           />
-        )}
+        ) : null}
       </div>
     );
   };

--- a/h5p-bildetema/src/context/SearchParamContext.tsx
+++ b/h5p-bildetema/src/context/SearchParamContext.tsx
@@ -1,0 +1,88 @@
+import React, { useState, createContext, useMemo, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
+import { useToggleSearchParam } from "../hooks/useToggleSearchParam";
+import { SearchParameters } from "../enums/SearchParameters";
+
+export type SearchParamContextType = {
+  showArticles: boolean;
+  showWrittenWords: boolean;
+  handleShowArticlesChange: (value: boolean) => void;
+  handleShowWrittenWordsChange: (value: boolean) => void;
+  syncStateWithParams: () => void;
+};
+
+export const SearchParamContext = createContext<
+  SearchParamContextType | undefined
+>(undefined);
+
+const defaultShowWrittenWords = true;
+const defaultShowArticles = false;
+
+type SearchParamProviderType = {
+  children: React.ReactNode;
+};
+
+export const SearchParamProvider = ({
+  children,
+}: SearchParamProviderType): JSX.Element => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const [showWrittenWords, setShowWrittenWords] = useState(
+    searchParams.get(SearchParameters.wordsVisible) !== null
+      ? searchParams.get(SearchParameters.wordsVisible) === "true"
+      : defaultShowWrittenWords,
+  );
+
+  const [showArticles, setShowArticles] = useState(
+    searchParams.get(SearchParameters.articlesVisible) !== null
+      ? searchParams.get(SearchParameters.articlesVisible) === "true"
+      : defaultShowArticles,
+  );
+
+  const handleShowArticlesChange = useToggleSearchParam(
+    SearchParameters.articlesVisible,
+    defaultShowArticles,
+    setShowArticles,
+  );
+
+  const handleShowWrittenWordsChange = useToggleSearchParam(
+    SearchParameters.wordsVisible,
+    defaultShowWrittenWords,
+    setShowWrittenWords,
+  );
+
+  const syncStateWithParams = useCallback(() => {
+    if (showWrittenWords !== defaultShowWrittenWords) {
+      searchParams.set(SearchParameters.wordsVisible, String(showWrittenWords));
+    }
+
+    if (showArticles !== defaultShowArticles) {
+      searchParams.set(SearchParameters.articlesVisible, String(showArticles));
+    }
+
+    setSearchParams(searchParams);
+  }, [searchParams, setSearchParams, showArticles, showWrittenWords]);
+
+  const values: SearchParamContextType = useMemo(
+    () => ({
+      showArticles,
+      showWrittenWords,
+      handleShowArticlesChange,
+      handleShowWrittenWordsChange,
+      syncStateWithParams,
+    }),
+    [
+      handleShowArticlesChange,
+      handleShowWrittenWordsChange,
+      showArticles,
+      showWrittenWords,
+      syncStateWithParams,
+    ],
+  );
+
+  return (
+    <SearchParamContext.Provider value={values}>
+      {children}
+    </SearchParamContext.Provider>
+  );
+};

--- a/h5p-bildetema/src/hooks/useCurrentWords.ts
+++ b/h5p-bildetema/src/hooks/useCurrentWords.ts
@@ -4,9 +4,11 @@ import { getMainTopics, getNewWordsFromId } from "common/utils/data.utils";
 import { uriComponentToTopicPath } from "common/utils/router.utils";
 import { useMemo } from "react";
 import { useLocation } from "react-router-dom";
+import { useSelectedNewWords } from "./useSelectedWords";
 
 export const useCurrentWords = (): NewWord[] => {
   const { topicPaths, idToWords, idToContent } = useNewDBContext();
+  const selectedWords = useSelectedNewWords();
 
   const { pathname } = useLocation();
 
@@ -25,6 +27,9 @@ export const useCurrentWords = (): NewWord[] => {
     return { topic, subTopic };
   }, [idToWords, pathname, topicPaths]);
 
+  if (selectedWords && selectedWords.length > 0) {
+    return selectedWords;
+  }
   if (currTopics.subTopic?.id) {
     return getNewWordsFromId(currTopics.subTopic?.id, idToWords, idToContent);
   }

--- a/h5p-bildetema/src/hooks/useSearchParamContext.ts
+++ b/h5p-bildetema/src/hooks/useSearchParamContext.ts
@@ -1,0 +1,13 @@
+import { useContext } from "react";
+import {
+  SearchParamContext,
+  SearchParamContextType,
+} from "../context/SearchParamContext";
+
+export const useSearchParamContext = (): SearchParamContextType => {
+  const context = useContext(SearchParamContext);
+  if (context === undefined) {
+    throw new Error("useSearchParamContext must be used within a page.");
+  }
+  return context;
+};

--- a/h5p-bildetema/src/hooks/useSelectedWords.ts
+++ b/h5p-bildetema/src/hooks/useSelectedWords.ts
@@ -42,7 +42,7 @@ export const useSelectedNewWords = (): NewWord[] => {
       })
       .filter(el => el !== undefined);
 
-    return newWords;
+    return newWords as NewWord[];
   }
   return [];
 };

--- a/h5p-bildetema/src/hooks/useSelectedWords.ts
+++ b/h5p-bildetema/src/hooks/useSelectedWords.ts
@@ -27,3 +27,22 @@ export const useSelectedWords = (): SearchResult[] => {
   }
   return [];
 };
+
+export const useSelectedNewWords = (): NewWord[] => {
+  const { idToWords } = useNewDBContext();
+  const { search } = useLocation();
+  const params = new URLSearchParams(search);
+  const words = params.get("words")?.split(",");
+
+  if (words?.length && words.length > 0) {
+    const newWords = words
+      .map(wordId => {
+        const newWord = idToWords.get(wordId);
+        return newWord;
+      })
+      .filter(el => el !== undefined);
+
+    return newWords;
+  }
+  return [];
+};

--- a/h5p-bildetema/src/hooks/useToggleSearchParam.ts
+++ b/h5p-bildetema/src/hooks/useToggleSearchParam.ts
@@ -12,12 +12,10 @@ export const useToggleSearchParam = (
   return (value: boolean) => {
     if (defaultValue === value) {
       searchParams.delete(search);
-      setSearchParams(searchParams);
-      setState(value);
-      return;
+    } else {
+      searchParams.set(search, String(value));
     }
 
-    searchParams.set(search, value.toString());
     setSearchParams(searchParams);
     setState(value);
   };

--- a/h5p-bildetema/src/hooks/useToggleSearchParam.ts
+++ b/h5p-bildetema/src/hooks/useToggleSearchParam.ts
@@ -1,0 +1,24 @@
+import { useSearchParams } from "react-router-dom";
+import { SearchParameters } from "../enums/SearchParameters";
+
+// Will return a function to toggle the searchParam on and off.
+export const useToggleSearchParam = (
+  search: SearchParameters,
+  defaultValue: boolean,
+  setState: React.Dispatch<React.SetStateAction<boolean>>,
+): ((value: boolean) => void) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  return (value: boolean) => {
+    if (defaultValue === value) {
+      searchParams.delete(search);
+      setSearchParams(searchParams);
+      setState(value);
+      return;
+    }
+
+    searchParams.set(search, value.toString());
+    setSearchParams(searchParams);
+    setState(value);
+  };
+};

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 77,
+  "patchVersion": 78,
   "runnable": 0,
   "preloadedJs": [
     {


### PR DESCRIPTION
## Description

✅ Added print, showArticles and showWords toggle to collection page
✅ Minor refactor to SubHeader component so that it can be used on the collection page

## References

[Trello-408](https://trello.com/c/7PZQILja/408-legge-til-print-vis-ord-og-vis-artikkel-i-visningen-av-en-samling)

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactor (non-breaking change which improves existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

<!--
  ⚠️ IMPORTANT ⚠️
  - DELETE EVERYTHING FROM THIS COMMENT ONWARDS BEFORE MERGING PR
  - Squash merge with the following message:
    <type>(<epicCode>): [<ticketCode>] (scope) - shortText
    i.e.: feat(er-324): [er-2563] (AvtaleGiro) - Agreement summary screen
-->

## Visuals

<img width="1591" alt="Skjermbilde 2024-04-29 kl  09 43 58" src="https://github.com/Tietoevry-Create/h5p-bildetema/assets/25177109/0cbabef0-c3e4-437c-bfd8-e05ab88651a7">

## Checklist:

<!--- Ensure quality. Put an `x` in all that apply -->

- [ ] I have added unit tests to cover my changes
- [ ] I have tested my code locally for app - ios
- [ ] I have tested my code locally for app - android
- [x] I have tested my code locally for web
- [ ] I have updated the documentation (created stories where apply) accordingly
- [x] I updated the ticket status
- [x] I confirm that new and existing tests passed