### PR TITLE
build: generate types for semantics on build

### DIFF
--- a/h5p-bildetema-words-grid-view/src/index.tsx
+++ b/h5p-bildetema-words-grid-view/src/index.tsx
@@ -1,6 +1,12 @@
-import { registerContentType } from "h5p-utils";
 import "common/polyfills";
+import { registerContentType } from "h5p-utils";
+import semantics from "../semantics.json";
 import { H5PWrapper } from "./h5p/H5PWrapper";
 import "./index.scss";
 
 registerContentType("BildetemaWordsGridView", H5PWrapper);
+
+// Import semantics into value space to ensure that `unplugin-json-dts`
+// generates the correct types.
+// eslint-disable-next-line no-unused-expressions
+semantics;

--- a/h5p-bildetema-words-grid-view/src/types/Params.ts
+++ b/h5p-bildetema-words-grid-view/src/types/Params.ts
@@ -2,8 +2,3 @@ import { InferParamsFromSemantics } from "h5p-types";
 import semantics from "../../semantics.json";
 
 export type Params = InferParamsFromSemantics<typeof semantics>;
-
-// Import semantics into value space to ensure that `unplugin-json-dts`
-// generates the correct types.
-// eslint-disable-next-line no-unused-expressions
-semantics;

--- a/h5p-bildetema-words-topic-image/semantics.json.d.ts
+++ b/h5p-bildetema-words-topic-image/semantics.json.d.ts
@@ -7,7 +7,7 @@ declare const $defaultExport: [
 	{
 		label: "Backend Url",
 		name: "backendUrl",
-		"default": "https://cdn-prod-bildetema.azureedge.net/data/database.json.tar.gz",
+		"default": "https://cdn-prod-bildetema.azureedge.net/data/data.json.tar.gz",
 		description: "The Url to the json database",
 		type: "text"
 	},
@@ -217,6 +217,18 @@ declare const $defaultExport: [
 		type: "boolean",
 		"default": false,
 		importance: "low"
+	},
+	{
+		label: "Show only topic image",
+		name: "showOnlyTopicImage",
+		type: "boolean",
+		"default": false
+	},
+	{
+		label: "Publish",
+		name: "isPublished",
+		type: "boolean",
+		"default": false
 	}
 ];
 export default $defaultExport;

--- a/h5p-bildetema-words-topic-image/src/index.tsx
+++ b/h5p-bildetema-words-topic-image/src/index.tsx
@@ -1,6 +1,12 @@
-import { registerContentType } from "h5p-utils";
 import "common/polyfills";
+import { registerContentType } from "h5p-utils";
+import semantics from "../semantics.json";
 import { H5PWrapper } from "./h5p/H5PWrapper";
 import "./index.scss";
 
 registerContentType("BildetemaTopicImageView", H5PWrapper);
+
+// Import semantics into value space to ensure that `unplugin-json-dts`
+// generates the correct types.
+// eslint-disable-next-line no-unused-expressions
+semantics;

--- a/h5p-bildetema-words-topic-image/src/types/Params.ts
+++ b/h5p-bildetema-words-topic-image/src/types/Params.ts
@@ -2,8 +2,3 @@ import type { InferParamsFromSemantics } from "h5p-types";
 import semantics from "../../semantics.json";
 
 export type Params = InferParamsFromSemantics<typeof semantics>;
-
-// Import semantics into value space to ensure that `unplugin-json-dts`
-// generates the correct types.
-// eslint-disable-next-line no-unused-expressions
-semantics;

--- a/h5p-bildetema/src/index.tsx
+++ b/h5p-bildetema/src/index.tsx
@@ -1,6 +1,12 @@
-import { registerContentType } from "h5p-utils";
 import "common/polyfills";
+import { registerContentType } from "h5p-utils";
+import semantics from "../semantics.json";
 import { H5PWrapper } from "./h5p/H5PWrapper";
 import "./index.scss";
 
 registerContentType("Bildetema", H5PWrapper);
+
+// Import semantics into value space to ensure that `unplugin-json-dts`
+// generates the correct types.
+// eslint-disable-next-line no-unused-expressions
+semantics;

--- a/h5p-bildetema/src/types/Params.ts
+++ b/h5p-bildetema/src/types/Params.ts
@@ -3,7 +3,3 @@ import semantics from "../../semantics.json";
 
 export type Params = InferParamsFromSemantics<typeof semantics>;
 
-// Import semantics into value space to ensure that `unplugin-json-dts`
-// generates the correct types.
-// eslint-disable-next-line no-unused-expressions
-semantics;

--- a/h5p-bildetema/src/types/Params.ts
+++ b/h5p-bildetema/src/types/Params.ts
@@ -2,4 +2,3 @@ import { InferParamsFromSemantics } from "h5p-types";
 import semantics from "../../semantics.json";
 
 export type Params = InferParamsFromSemantics<typeof semantics>;
-

--- a/turbo.json
+++ b/turbo.json
@@ -3,7 +3,7 @@
   "pipeline": {
     "build": {
       "dependsOn": ["^build"],
-      "outputs": ["dist/**/*"]
+      "outputs": ["dist/**/*", "**/*.json.d.ts"]
     },
     "test": {
       "inputs": ["src/**/*.tsx", "src/**/*.ts", "test/**/*.ts", "test/**/*.tsx"]


### PR DESCRIPTION
## Description

Move `semantics;` call to entry points to make sure that Vite picks them up and doesn't compile them away. By being part of the compile process, `unplugin-json-dts` will be able to generate types for semantics.

## Types of changes

- [x] Change to build system
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Verification

1. Check out the branch locally
1. Do a change to the `semantics.json` files
1. Build the project
1. See that changes affect `semantics.json.d.ts` files