### PR TITLE
fix: remove search button link from empty collections

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 236,
+  "patchVersion": 237,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
@@ -75,13 +75,15 @@ const CollectionPage = ({
         <p className={styles.description}>{`${thisCollectionIsEmpty}.`}</p>
         <p className={styles.description}>{descriptionWithLinks}</p>
         <div className={styles.navButtons}>
-          <Button
-            variant="default"
-            role="link"
-            onClick={() => navigate(STATIC_PATH.SEARCH)}
-          >
-            {goToSearch}
-          </Button>
+          {shouldIncludeSearch && (
+            <Button
+              variant="default"
+              role="link"
+              onClick={() => navigate(STATIC_PATH.SEARCH)}
+            >
+              {goToSearch}
+            </Button>
+          )}
           <Button variant="default" role="link" onClick={() => navigate("/")}>
             {goToTopic}
           </Button>


### PR DESCRIPTION
for environments that shouldn't display search