### PR TITLE
feat: collections page edits

### DIFF
--- a/common/abstracts/_variables.scss
+++ b/common/abstracts/_variables.scss
@@ -25,7 +25,7 @@ $white: #ffffff;
 $grey: #eee;
 $beige: #f6f5f4;
 $dark-beige: #ebeae8;
-$darker-beige: #c0bfbd;
+$darker-beige: #ddd8d7;
 $dark-teal: #007271;
 $teal: #71b0b0;
 $light-teal: #e6f1f1;

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 108,
+  "patchVersion": 109,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/library.json.d.ts
+++ b/h5p-bildetema-words-grid-view/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "H5P Bildetema Words Grid View";
 export const machineName : "H5P.BildetemaWordsGridView";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 108;
+export const patchVersion : 109;
 export const runnable : 1;
 export const preloadedJs : [
 	{

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 112,
+  "patchVersion": 113,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 239,
+  "patchVersion": 240,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/CollectionsController/CollectionController.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionController.module.scss
@@ -10,7 +10,7 @@
   margin: $main-content-margin;
   width: $main-content-width;
   max-width: $main-content-max-width;
-  margin-bottom: 2rem;
+  margin-bottom: 3rem;
 }
 .menuWrapper {
   padding: 2rem 0rem;

--- a/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.module.scss
@@ -65,5 +65,6 @@
 
   &:hover {
     background-color: $darker-beige;
+    fill: inherit;
   }
 }

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.module.scss
@@ -76,4 +76,5 @@ $gap: $spacing--24;
 .description {
   all: unset;
   font-size: $font-size-16;
+  line-height: 1.4;
 }

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
@@ -27,6 +27,7 @@
 
 .description {
   line-height: 1.4;
+  margin: 0;
   max-width: 48rem;
 }
 

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
@@ -26,6 +26,7 @@
 }
 
 .description {
+  line-height: 1.4;
   max-width: 48rem;
 }
 

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
@@ -66,7 +66,7 @@ const CollectionsPage = (): React.JSX.Element => {
           </div>
         </div>
       </Dialog>
-      <div className={styles.description}>{collectionsPageDescription}</div>
+      <p className={styles.description}>{collectionsPageDescription}</p>
       <Button
         className={styles.addButton}
         variant="default"

--- a/h5p-bildetema/src/components/Menu/Menu.module.scss
+++ b/h5p-bildetema/src/components/Menu/Menu.module.scss
@@ -8,6 +8,10 @@
   border-radius: 5px;
   box-shadow: 0 0 10px 1px rgba(0, 0, 0, 0.2);
   background-color: $white;
+
+  &:focus-visible {
+    outline: $outline-on-light-background;
+  }
 }
 
 .menuItemButton {
@@ -19,8 +23,8 @@
   padding: 1.5rem 2rem;
   font-family: sans-serif;
 
-  &:hover {
-    background-color: $grey;
-    border-radius: 5px;
+  &:hover,
+  &[data-focus] {
+    background-color: $beige;
   }
 }

--- a/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
+++ b/h5p-bildetema/src/components/SubHeader/SubHeader.tsx
@@ -12,6 +12,7 @@ import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
 import { useSearchParamContext } from "../../hooks/useSearchParamContext";
 import ShareButton from "../ShareButton/ShareButton";
 import SaveSharedCollectionButton from "../SaveSharedCollectionButton/SaveSharedCollectionButton";
+import useCurrentCollection from "../../hooks/useCurrentCollection";
 
 export type SubHeaderProps = {
   topicsSize?: TopicGridSizes;
@@ -52,6 +53,9 @@ export const SubHeader: FC<SubHeaderProps> = ({
     handleShowWrittenWordsChange,
     syncStateWithParams,
   } = useSearchParamContext();
+
+  const { isACollection, isCollectionOwner } = useCurrentCollection();
+  const hideBreadCrumbs = isACollection && !isCollectionOwner;
 
   const contentId = useContentId();
 
@@ -110,16 +114,16 @@ export const SubHeader: FC<SubHeaderProps> = ({
         isWordView ? styles.subHeaderWords : styles.subHeaderThemes
       } ${rtl ? styles.rtl : ""}`}
     >
-      {!includeSaveButton ? (
+      {hideBreadCrumbs ? (
+        <h1 className={styles.currentPage}>
+          {breadCrumbs ? breadCrumbs[breadCrumbs.length - 1].label : ""}
+        </h1>
+      ) : (
         <Breadcrumbs
           currentLanguageCode={currentLanguageCode as LanguageCode}
           currentTopics={currentTopics}
           breadCrumbs={breadCrumbs}
         />
-      ) : (
-        <h1 className={styles.currentPage}>
-          {breadCrumbs ? breadCrumbs[breadCrumbs.length - 1].label : ""}
-        </h1>
       )}
       {renderRightMenu()}
     </div>

--- a/h5p-bildetema/src/components/TopicRouteController/TopicRouteController.module.scss
+++ b/h5p-bildetema/src/components/TopicRouteController/TopicRouteController.module.scss
@@ -1,7 +1,7 @@
 @use "../../../../common/abstracts" as *;
 
 .body {
-  padding: 2rem 0;
+  padding: 2rem 0 3rem;
   display: flex;
   flex-direction: column;
   flex-grow: 1;

--- a/h5p-bildetema/src/hooks/useCurrentCollection.ts
+++ b/h5p-bildetema/src/hooks/useCurrentCollection.ts
@@ -5,12 +5,14 @@ import { useSearchParams } from "react-router-dom";
 const useCurrentCollection = () => {
   const [searchParams] = useSearchParams();
   const collectionId = searchParams.get("id") ?? "";
+  const isACollection = searchParams.has("id") && searchParams.has("words");
   const { myCollections } = useMyCollections();
 
   const collection = myCollections.find(c => c.id === collectionId);
   const isCollectionOwner = !!collection;
 
   return {
+    isACollection,
     isCollectionOwner,
     collectionId: collection?.id,
     collectionName: collection?.title,

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 96,
+  "patchVersion": 97,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json.d.ts
+++ b/h5p-editor-bildetema-words-topic-image/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "Bildetema Words Topic Image Editor";
 export const machineName : "H5PEditor.BildetemaWordsTopicImage";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 96;
+export const patchVersion : 97;
 export const runnable : 0;
 export const preloadedJs : [
 	{


### PR DESCRIPTION
- Makes the font-size larger and increases the line-height of the description on the collections page.
- Makes the (kebab) menu button on the collections dark (not negative with white icon on dark background) and makes the hover background more similar to the other beige variables used. 
- Adds breadcrumbs to the collections page. Was previously hidden, but make sense to include it as the collection pages do have it and there it includes "home" as the start page. 