### PR TITLE
fix so that it will scroll to top when navigating to front page

### DIFF
--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 244,
+  "patchVersion": 245,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/TopicRouteController/TopicRouteController.tsx
+++ b/h5p-bildetema/src/components/TopicRouteController/TopicRouteController.tsx
@@ -29,6 +29,7 @@ export const TopicRouteController: FC<TopicRouteControllerProps> = ({
   const h5pInstance = useH5PInstance<H5PWrapper>();
   const currentLang = useCurrentLanguageAttribute();
   const currentLanguageCode = useCurrentLanguageCode();
+  const [prevLanguageCode, setPrevLanguageCode] = useState(currentLanguageCode);
   const newWords = useCurrentWords();
   const { topicPaths, idToContent, langCodeTolanguages } = useNewDBContext();
   const { showArticles, showWrittenWords } = useSearchParamContext();
@@ -76,7 +77,6 @@ export const TopicRouteController: FC<TopicRouteControllerProps> = ({
       return;
     }
     const isFrontpage = !topicLabelParam;
-    const previousPageWasFrontpage = !currentTopicId && !currentSubTopicId;
 
     let newTopicId: string | undefined;
     let topicHasChanged = false;
@@ -109,17 +109,19 @@ export const TopicRouteController: FC<TopicRouteControllerProps> = ({
     }
     subTopicHasChanged = newSubTopicId !== currentSubTopicId;
 
-    // If the previous page was the frontpage AND the new page is the frontpage,
-    // then we shouldn't trigger scroll into view, because it means that something
-    // other than the topic or sub topic was changed (language or search params).
+    const languageChanged = prevLanguageCode !== currentLanguageCode;
+
+    // Scroll to top if frontpage, topic or subtopic changes.
+    // Should not scroll to top just because language changes.
     const shouldScrollIntoView =
-      (isFrontpage && !previousPageWasFrontpage) ||
+      (isFrontpage && !languageChanged) ||
       topicHasChanged ||
       subTopicHasChanged;
     if (shouldScrollIntoView) {
       h5pInstance?.getWrapper().scrollIntoView();
     }
 
+    setPrevLanguageCode(currentLanguageCode);
     setCurrentTopicId(newTopicId);
     setCurrentSubTopicId(newSubTopicId);
 


### PR DESCRIPTION
## Description

✅ fix so that it will scroll to top when navigating to front page from collections page (or any other page)

## References

[Trello-426](https://trello.com/c/vKSYHqcc/426-lag-link-for-s%C3%B8k-og-tema-i-beskrivelsetekst-i-samlinger)

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactor (non-breaking change which improves existing functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
