### PR TITLE
fix: scroll into view and include language code in hrefs

### DIFF
--- a/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
@@ -1,7 +1,8 @@
 import { useParams } from "react-router-dom";
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 import { STATIC_PATH } from "common/constants/paths";
 import { searchResultsIncludesArticles } from "common/utils/word.utils";
+import { useH5PInstance } from "use-h5p";
 import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
 import styles from "./CollectionController.module.scss";
 import CollectionPage from "./CollectionPage/CollectionPage";
@@ -11,6 +12,7 @@ import { useSelectedWords } from "../../hooks/useSelectedWords";
 import { useSearchParamContext } from "../../hooks/useSearchParamContext";
 import useCurrentCollection from "../../hooks/useCurrentCollection";
 import { useL10ns } from "../../hooks/useL10n";
+import { H5PWrapper } from "../../h5p/H5PWrapper";
 
 type CollectionControllerProps = {
   rtl: boolean;
@@ -19,9 +21,10 @@ type CollectionControllerProps = {
 const CollectionController = ({
   rtl,
 }: CollectionControllerProps): JSX.Element => {
-  const { collection } = useParams();
+  const h5pInstance = useH5PInstance<H5PWrapper>();
   const langCode = useCurrentLanguageCode();
   const words = useSelectedWords();
+  const { collection } = useParams();
   const { showArticles, showWrittenWords } = useSearchParamContext();
   const { isCollectionOwner } = useCurrentCollection();
   const { breadcrumbsHome, myCollections } = useL10ns(
@@ -66,6 +69,12 @@ const CollectionController = ({
       />
     );
   };
+
+  useEffect(() => {
+    // Scroll into view on load and if collection param changes (i.e. when
+    // switching between the main collection page and a collection)
+    h5pInstance?.getWrapper().scrollIntoView();
+  }, [collection, h5pInstance]);
 
   return (
     <div className={`${styles.CollectionController} ${styles.mainSize}`}>

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
@@ -48,7 +48,7 @@ const CollectionPage = ({
 
   const replacements = {
     search: (
-      <Link key={1} to={STATIC_PATH.SEARCH}>
+      <Link key={1} to={`${STATIC_PATH.SEARCH}?lang=${lang.code}`}>
         {search.toLowerCase()}
       </Link>
     ),
@@ -78,12 +78,18 @@ const CollectionPage = ({
             <Button
               variant="default"
               role="link"
-              onClick={() => navigate(STATIC_PATH.SEARCH)}
+              onClick={() =>
+                navigate(`${STATIC_PATH.SEARCH}?lang=${lang.code}`)
+              }
             >
               {goToSearch}
             </Button>
           )}
-          <Button variant="default" role="link" onClick={() => navigate("/")}>
+          <Button
+            variant="default"
+            role="link"
+            onClick={() => navigate(`/${lang.code}`)}
+          >
             {goToTopic}
           </Button>
         </div>

--- a/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
@@ -40,7 +40,10 @@ const SearchView = ({
         currentLanguageCode={searchLanguage.code}
         breadCrumbs={[
           { label: breadcrumbsHome, path: `/${langCode}` },
-          { label: breadcrumbsSearch, path: `${STATIC_PATH.SEARCH}` },
+          {
+            label: breadcrumbsSearch,
+            path: `${STATIC_PATH.SEARCH}?lang=${langCode}`,
+          },
         ]}
       />
       <div className={styles.wrapper}>

--- a/h5p-bildetema/src/components/TopicRouteController/TopicRouteController.tsx
+++ b/h5p-bildetema/src/components/TopicRouteController/TopicRouteController.tsx
@@ -38,6 +38,8 @@ export const TopicRouteController: FC<TopicRouteControllerProps> = ({
   const [currentTopicId, setCurrentTopicId] = useState<string>();
   const [currentSubTopicId, setCurrentSubTopicId] = useState<string>();
   const [showTopicImageView, setShowTopicImageView] = useState(true);
+  const [previousPageWasFrontpage, setPreviousPageWasFrontpage] =
+    useState(false);
 
   const smallScreen = window.matchMedia("(max-width: 768px)").matches;
   const [topicsSize, setTopicsSize] = useState(
@@ -76,7 +78,6 @@ export const TopicRouteController: FC<TopicRouteControllerProps> = ({
       return;
     }
     const isFrontpage = !topicLabelParam;
-    const previousPageWasFrontpage = !currentTopicId && !currentSubTopicId;
 
     let newTopicId: string | undefined;
     let topicHasChanged = false;
@@ -122,6 +123,7 @@ export const TopicRouteController: FC<TopicRouteControllerProps> = ({
 
     setCurrentTopicId(newTopicId);
     setCurrentSubTopicId(newSubTopicId);
+    setPreviousPageWasFrontpage(isFrontpage);
 
     // Avoid depending on `currentTopicId` and `currentSubTopicId` as they are set by the effect
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/h5p-bildetema/src/hooks/useCurrentLanguage.ts
+++ b/h5p-bildetema/src/hooks/useCurrentLanguage.ts
@@ -3,6 +3,7 @@ import { attributeLanguages } from "common/constants/languages";
 import { LanguageCode, isLanguageCode } from "common/types/LanguageCode";
 import { useNewDBContext } from "common/hooks/useNewDBContext";
 import { Language } from "common/types/types";
+import { STATIC_PATH } from "common/constants/paths";
 
 export const useCurrentLanguageCode = (): LanguageCode => {
   const { pathname } = useLocation();
@@ -43,9 +44,18 @@ export const useCurrentLanguage = (): Language => {
 export const getCurrentLanguageCode = (): LanguageCode => {
   const pathname = window.location.hash;
 
+  const isSearchPage = pathname.includes(STATIC_PATH.SEARCH);
+
   // Extract language code from pathname
-  const pathSegments = pathname.split("/").filter(Boolean);
-  const langFromPath = pathSegments.length > 0 ? pathSegments[1] : "";
+  let langFromPath = "";
+
+  if (isSearchPage) {
+    const pathSegments = pathname.split("lang=").filter(Boolean);
+    langFromPath = pathSegments[1].substring(0, 3);
+  } else {
+    const pathSegments = pathname.split("/").filter(Boolean);
+    langFromPath = pathSegments.length > 0 ? pathSegments[1] : "";
+  }
 
   if (isLanguageCode(langFromPath)) {
     return langFromPath;


### PR DESCRIPTION
- Fixes problem with "scroll into view" when entering a new page.
- Fixes problems with wrong href on links, not including the language code. The current language was therefore not always correct when changing between collection pages, topic pages and search page. 

Related to Trello-issue: https://trello.com/c/vKSYHqcc/426-lag-link-for-s%C3%B8k-og-tema-i-beskrivelsetekst-i-samlinger 