### PR TITLE
fix: change search result order

### DIFF
--- a/common/utils/searchResults.utils.ts
+++ b/common/utils/searchResults.utils.ts
@@ -34,8 +34,8 @@ export const sortSearchByTopic = (results: NewWord[]): NewWord[] => {
 const getSearchPositionValue = (search: string, labels: Labels): number => {
   const equal = 0;
   const equalWithin = 1;
-  const endsWith = 2;
-  const startsWith = 3;
+  const startsWith = 2;
+  const endsWith = 3;
   const contains = 5;
 
   const lowerCaseSearch = search.toLowerCase();

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 114,
+  "patchVersion": 115,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/library.json.d.ts
+++ b/h5p-bildetema-words-grid-view/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "H5P Bildetema Words Grid View";
 export const machineName : "H5P.BildetemaWordsGridView";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 114;
+export const patchVersion : 115;
 export const runnable : 1;
 export const preloadedJs : [
 	{

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 118,
+  "patchVersion": 119,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 246,
+  "patchVersion": 247,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 102,
+  "patchVersion": 103,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json.d.ts
+++ b/h5p-editor-bildetema-words-topic-image/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "Bildetema Words Topic Image Editor";
 export const machineName : "H5PEditor.BildetemaWordsTopicImage";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 102;
+export const patchVersion : 103;
 export const runnable : 0;
 export const preloadedJs : [
 	{


### PR DESCRIPTION
Changes the order of the search results. Words starting with the search term will be shown before words that ends with the search term.

Relates to Trello-issue: https://trello.com/c/z1CKejCr/452-s%C3%B8k-treff-virker-ikke-logisk