### PR TITLE
fix: topic filter in Firefox, and make filter more accessible

### DIFF
--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -253,10 +253,6 @@
           "default": "Add words by clicking on the bookmark on the images via {{topicView}}."
         },
         {
-          "label": "Filter by theme",
-          "default": "Filter by theme"
-        },
-        {
           "label": "Collections Page Description",
           "default": "Here you can save words in your own collections. The collections will only be stored in this browser. If you want to share the collection or view it elsewhere, you can copy the link to the collection."
         },

--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -365,6 +365,10 @@
           "default": "Reset filter"
         },
         {
+          "label": "Close filter",
+          "default": "Close filter"
+        },
+        {
           "label": "View language label",
           "default": "Show in multiple languages"
         },

--- a/h5p-bildetema/language/da.json
+++ b/h5p-bildetema/language/da.json
@@ -253,10 +253,6 @@
           "default": "Tilføj ord ved at klikke på bogmærket på billederne via {{topicView}}."
         },
         {
-          "label": "Filter by theme",
-          "default": "Filtrer efter tema"
-        },
-        {
           "label": "Collections Page Description",
           "default": "Her kan du gemme ord i dine egne samlinger. Samlingerne vil kun blive gemt i denne browser. Hvis du vil dele samlingen eller se den andre steder, kan du kopiere linket til samlingen."
         },
@@ -363,6 +359,10 @@
         {
           "label": "Topic filter reset",
           "default": "Nulstil filter"
+        },
+        {
+          "label": "Close filter",
+          "default": "Luk filteret"
         },
         {
           "label": "View language label",

--- a/h5p-bildetema/language/is.json
+++ b/h5p-bildetema/language/is.json
@@ -253,10 +253,6 @@
           "default": "Bættu við orðum með því að smella á bókamerkið á myndunum í gegnum {{topicView}}."
         },
         {
-          "label": "Filter by theme",
-          "default": "Sía eftir þema"
-        },
-        {
           "label": "Collections Page Description",
           "default": "Hér getur þú vistað orð í þínum eigin söfnum. Söfnin verða aðeins geymd í þessum vafra. Ef þú vilt deila safninu eða skoða það annars staðar geturðu afritað hlekkinn á safnið."
         },
@@ -363,6 +359,10 @@
         {
           "label": "Topic filter reset",
           "default": "Endurstilla síu"
+        },
+        {
+          "label": "Close filter",
+          "default": "Lokaðu síu"
         },
         {
           "label": "View language label",

--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -253,10 +253,6 @@
           "default": "Legg til ord ved å klikke på bokmerket på bildene via {{topicView}}."
         },
         {
-          "label": "Filter by theme",
-          "default": "Filtrer etter tema"
-        },
-        {
           "label": "Collections Page Description",
           "default": "Her kan du lagre ord i dine egne samlinger. Samlingene vil kun lagres i denne nettleseren. Om du ønsker å dele samlingen eller se den andre steder, kan du kopiere lenken til samlingen."
         },
@@ -363,6 +359,10 @@
         {
           "label": "Topic filter reset",
           "default": "Nullstill filter"
+        },
+        {
+          "label": "Close filter",
+          "default": "Lukk filter"
         },
         {
           "label": "View language label",

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -253,10 +253,6 @@
           "default": "Legg til ord ved å klikke på bokmerket på bileta via {{topicView}}."
         },
         {
-          "label": "Filter by theme",
-          "default": "Filtrer etter tema"
-        },
-        {
           "label": "Collections Page Description",
           "default": "Her kan du lagra ord i dine eigne samlingar. Samlingane vil berre lagrast i denne nettlesaren. Om du ønskjer å dela samlinga eller sjå den andre stader, kan du kopiera lenkja til samlinga."
         },
@@ -363,6 +359,10 @@
         {
           "label": "Topic filter reset",
           "default": "Nullstill filtar"
+        },
+        {
+          "label": "Close filter",
+          "default": "Lukk filtar"
         },
         {
           "label": "View language label",

--- a/h5p-bildetema/language/sv.json
+++ b/h5p-bildetema/language/sv.json
@@ -253,10 +253,6 @@
           "default": "Lägg till ord genom att klicka på bokmärket på bilderna via {{topicView}}."
         },
         {
-          "label": "Filter by theme",
-          "default": "Filtrera efter tema"
-        },
-        {
           "label": "Collections Page Description",
           "default": "Här kan du spara ord i dina egna samlingar. Samlingarna kommer endast att lagras i den här webbläsaren. Om du vill dela samlingen eller se den någon annanstans kan du kopiera länken till samlingen."
         },
@@ -363,6 +359,10 @@
         {
           "label": "Topic filter reset",
           "default": "Återställ filter"
+        },
+        {
+          "label": "Close filter",
+          "default": "Stäng filtret"
         },
         {
           "label": "View language label",

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -379,12 +379,6 @@
         "type": "text"
       },
       {
-        "label": "Filter by theme",
-        "name": "filterByTheme",
-        "default": "Filter by theme",
-        "type": "text"
-      },
-      {
         "label": "Collections Page Description",
         "name": "collectionsPageDescription",
         "default": "Here you can save words in your own collections. The collections will only be stored in this browser. If you want to share the collection or view it elsewhere, you can copy the link to the collection.",
@@ -544,6 +538,12 @@
         "label": "Topic filter reset",
         "name": "topicFilterReset",
         "default": "Reset filter",
+        "type": "text"
+      },
+      {
+        "label": "Close filter",
+        "name": "topicFilterClose",
+        "default": "Close filter",
         "type": "text"
       },
       {

--- a/h5p-bildetema/semantics.json.d.ts
+++ b/h5p-bildetema/semantics.json.d.ts
@@ -379,12 +379,6 @@ declare const $defaultExport: [
 				type: "text"
 			},
 			{
-				label: "Filter by theme",
-				name: "filterByTheme",
-				"default": "Filter by theme",
-				type: "text"
-			},
-			{
 				label: "Collections Page Description",
 				name: "collectionsPageDescription",
 				"default": "Here you can save words in your own collections. The collections will only be stored in this browser. If you want to share the collection or view it elsewhere, you can copy the link to the collection.",
@@ -544,6 +538,12 @@ declare const $defaultExport: [
 				label: "Topic filter reset",
 				name: "topicFilterReset",
 				"default": "Reset filter",
+				type: "text"
+			},
+			{
+				label: "Close filter",
+				name: "topicFilterClose",
+				"default": "Close filter",
 				type: "text"
 			},
 			{

--- a/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.module.scss
@@ -54,16 +54,10 @@
   overflow-y: auto;
 }
 
-.searchFilter {
+.searchFilterWrapper {
   display: block;
   column-count: 1;
-  gap: 5rem;
-  font-size: $font-size-20;
-  line-height: 1;
-
-  @include breakpoint-min($x-small) {
-    column-count: 1;
-  }
+  column-gap: 5rem;
 
   @include breakpoint-min($small) {
     column-count: 2;
@@ -74,8 +68,16 @@
   @include breakpoint-min($large) {
     column-count: 4;
   }
-  @include breakpoint-min($x-large) {
-    // column-count: 5;
+}
+
+.searchFilter {
+  font-size: $font-size-20;
+  line-height: 1;
+  margin: 0;
+  padding: 0;
+
+  li {
+    list-style-type: none;
   }
 }
 
@@ -120,4 +122,8 @@
   font-weight: bold;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.visuallyHidden {
+  @include visually-hidden;
 }

--- a/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.tsx
@@ -21,9 +21,10 @@ const SearchFilterDialog = ({
   filter,
 }: SearchFilterProps): JSX.Element => {
   const { idToContent, idToWords } = useNewDBContext();
-  const { topicFilterTitle, topicFilterReset } = useL10ns(
+  const { topicFilterTitle, topicFilterReset, topicFilterClose } = useL10ns(
     "topicFilterTitle",
     "topicFilterReset",
+    "topicFilterClose",
   );
 
   const [isOpen, setIsOpen] = useState(false);
@@ -60,7 +61,9 @@ const SearchFilterDialog = ({
           <DialogPanel className={styles.panel}>
             <DialogTitle className={styles.titleWrapper}>
               <div className={styles.title}>
-                <Filter />
+                <span aria-hidden="true">
+                  <Filter />
+                </span>
                 <span className={styles.label}>{topicFilterTitle}</span>
               </div>
               <button
@@ -68,13 +71,18 @@ const SearchFilterDialog = ({
                 className={styles.closeButton}
                 onClick={() => setIsOpen(false)}
               >
-                <Close />
+                <span aria-hidden="true">
+                  <Close />
+                </span>
+                <span className={styles.visuallyHidden}>
+                  {topicFilterClose}
+                </span>
               </button>
             </DialogTitle>
-            <div className={styles.searchFilterBorderTop}>
-              <div className={styles.searchFilter}>
+            <div className={styles.searchFilterWrapper}>
+              <ul className={styles.searchFilter}>
                 {topics?.map(topic => (
-                  <div key={topic.id} className={styles.checkBoxWrapper}>
+                  <li key={topic.id} className={styles.checkBoxWrapper}>
                     <FilterCheckbox
                       key={topic.id}
                       id={topic.id}
@@ -86,9 +94,9 @@ const SearchFilterDialog = ({
                         topic.translations.get("nob")?.labels,
                       )}
                     />
-                  </div>
+                  </li>
                 ))}
-              </div>
+              </ul>
             </div>
             <Button variant="underline" onClick={resetFilter}>
               {topicFilterReset}


### PR DESCRIPTION
- Fixes issue with use of column-count in Firefox (better to use it on a parent element of the list than the actual list element)
- Adds a visually hidden label to the close button
- Adds a new translation for the close button and removes an unused translation
- Turns the parent element of the checkboxes into a unordered list, and the checkbox elements into list elements. This makes it more accessible for screen reader users. 

Related to Trello-card: https://trello.com/c/4zIsnXfn/453-filtrer-s%C3%B8k-firefox-p%C3%A5-mac 