### PR TITLE
fix: adjust collections after user test

### DIFF
--- a/common/components/Audio/Audio.tsx
+++ b/common/components/Audio/Audio.tsx
@@ -1,11 +1,13 @@
 import { SpeakerIcon, SpeakerPlayingIcon } from "common/components/Icons/Icons";
 import { useAudioRefContext } from "common/hooks/useAudioContext";
 import { FC, useEffect, useRef, useState } from "react";
+import { v4 as uuid } from "uuid";
 import styles from "./Audio.module.scss";
 import { AudioFile } from "../../types/AudioFile";
 
 type AudioProps = {
   lang: string;
+  labelLang?: string;
   stopAudioLabel: string;
   playAudioLabel: string;
   audioFiles?: AudioFile[];
@@ -16,6 +18,7 @@ type AudioProps = {
 
 export const Audio: FC<AudioProps> = ({
   label,
+  labelLang,
   audioFiles,
   lang,
   stopAudioLabel,
@@ -26,6 +29,7 @@ export const Audio: FC<AudioProps> = ({
   const audioRef = useRef<HTMLAudioElement>(null);
   const [playing, setPlaying] = useState(false);
   const { contextAudioRef, setContextAudioRef } = useAudioRefContext();
+  const descriptionId = uuid();
   const textVisible = !!label;
 
   const handleAudioEnded = (): void => {
@@ -78,6 +82,8 @@ export const Audio: FC<AudioProps> = ({
         type="button"
         onClick={toggleAudio}
         className={rtl ? styles.rtl : ""}
+        aria-describedby={descriptionId}
+        lang={labelLang}
       >
         {textVisible && (
           <h2
@@ -96,7 +102,12 @@ export const Audio: FC<AudioProps> = ({
             <SpeakerIcon className={styles.audioIcon} />
           )}
         </span>
-        <span className={styles.visuallyHidden} lang={lang}>
+        <span
+          id={descriptionId}
+          className={styles.visuallyHidden}
+          aria-hidden="true"
+          lang={lang}
+        >
           {playing ? stopAudioLabel : playAudioLabel}
         </span>
       </button>

--- a/common/components/ChooseCollectionsDialog/ChooseCollectionsDialog.tsx
+++ b/common/components/ChooseCollectionsDialog/ChooseCollectionsDialog.tsx
@@ -49,6 +49,7 @@ const ChooseCollectionsDialog = () => {
     ariaDisabledChooseACollection,
     ariaDisabledChooseACollectionPreselected,
     ariaDisabledCreateACollection,
+    nameOfTheCollection,
   } = useL10ns(
     "createACollection",
     "chooseACollection",
@@ -59,6 +60,7 @@ const ChooseCollectionsDialog = () => {
     "ariaDisabledChooseACollection",
     "ariaDisabledChooseACollectionPreselected",
     "ariaDisabledCreateACollection",
+    "nameOfTheCollection",
   );
 
   const description = showCreate ? createACollection : chooseACollection;
@@ -152,6 +154,7 @@ const ChooseCollectionsDialog = () => {
     >
       {showCreate ? (
         <NewOption
+          label={nameOfTheCollection}
           value={textInput}
           handleChange={value => setTextInput(value)}
           onCreateOption={handleConfirm}

--- a/common/components/ConfirmationDialog/ConfirmationDialog.tsx
+++ b/common/components/ConfirmationDialog/ConfirmationDialog.tsx
@@ -25,7 +25,7 @@ const ConfirmationDialog = ({
   disabledTooltip,
 }: ConfirmationDialogProps) => {
   const { isOpen, handleCloseDialog } = useDialogContext();
-  const { cancel } = useL10ns("cancel");
+  const { cancel, confirm } = useL10ns("cancel", "confirm");
 
   return (
     <Dialog open={isOpen} onClose={handleCloseDialog} title={title}>
@@ -40,7 +40,7 @@ const ConfirmationDialog = ({
           aria-disabled={disableConfirm}
           disabledTooltip={disabledTooltip}
         >
-          Ok
+          {confirm}
         </Button>
       </div>
     </Dialog>

--- a/common/components/NewOption/NewOption.tsx
+++ b/common/components/NewOption/NewOption.tsx
@@ -3,12 +3,14 @@ import React from "react";
 import TextInput from "common/components/TextInput/TextInput";
 
 interface NewOptionProps {
+  label: string;
   value: string;
   handleChange: (value: string) => void;
   onCreateOption: (optionName: string) => void;
 }
 
 const NewOption: React.FC<NewOptionProps> = ({
+  label,
   value,
   handleChange,
   onCreateOption,
@@ -27,6 +29,7 @@ const NewOption: React.FC<NewOptionProps> = ({
   return (
     <div>
       <TextInput
+        label={label}
         handleChange={handleNewOptionChange}
         handleEnter={handleCreateOption}
         value={value}

--- a/common/components/TextInput/TextInput.module.scss
+++ b/common/components/TextInput/TextInput.module.scss
@@ -4,14 +4,22 @@
 #TextInput {
   padding: 0.75rem 1.5rem;
   width: 100%;
-  border: 3px solid $dark-beige;
+  border: 2px solid $dark-beige;
   background-color: $beige;
   border-radius: 0.5rem;
   box-shadow: none;
   font-size: $font-size-18;
+  margin-top: 0.25rem;
+
+  &:hover {
+    border-color: $darker-beige;
+  }
 
   &:focus-visible {
     outline: $outline-on-light-background !important;
-    // outline: none !important;
   }
+}
+
+.label {
+  font-size: $font-size-16;
 }

--- a/common/components/TextInput/TextInput.tsx
+++ b/common/components/TextInput/TextInput.tsx
@@ -3,12 +3,14 @@ import styles from "./TextInput.module.scss";
 
 export type TextInputProps = {
   handleChange: (value: string) => void;
+  label: string;
   value: string;
   placeholder?: string;
   handleEnter?: () => void;
 };
 
 const TextInput = ({
+  label,
   placeholder,
   value,
   handleChange,
@@ -27,21 +29,23 @@ const TextInput = ({
   };
 
   return (
-    <input
-      ref={ref}
-      // TODO needs a label
-      id={styles.TextInput}
-      placeholder={placeholder ?? ""}
-      value={value}
-      autoComplete="off"
-      onChange={e => handleChange(e.target.value)}
-      onKeyDown={e => {
-        if (e.key === "Enter") {
-          e.preventDefault();
-          handleEnterPress();
-        }
-      }}
-    />
+    <label htmlFor={styles.TextInput}>
+      <span className={styles.label}>{label}</span>
+      <input
+        ref={ref}
+        id={styles.TextInput}
+        placeholder={placeholder ?? ""}
+        value={value}
+        autoComplete="off"
+        onChange={e => handleChange(e.target.value)}
+        onKeyDown={e => {
+          if (e.key === "Enter") {
+            e.preventDefault();
+            handleEnterPress();
+          }
+        }}
+      />
+    </label>
   );
 };
 

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 117,
+  "patchVersion": 118,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/library.json.d.ts
+++ b/h5p-bildetema-words-grid-view/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "H5P Bildetema Words Grid View";
 export const machineName : "H5P.BildetemaWordsGridView";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 117;
+export const patchVersion : 118;
 export const runnable : 1;
 export const preloadedJs : [
 	{

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 121,
+  "patchVersion": 122,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -221,6 +221,10 @@
           "default": "Cancel"
         },
         {
+          "label": "Confirm",
+          "default": "Ok"
+        },
+        {
           "label": "Aria text for disabled button in choose a collection dialog",
           "default": "Choose a collection"
         },

--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -250,7 +250,7 @@
         },
         {
           "label": "Description text for adding a word to a collection",
-          "default": "Add words by clicking on the bookmark on the images, either via {{search}} or {{topicView}}"
+          "default": "Add words via {{search}} or {{topicView}}. Click on the bookmark on the images."
         },
         {
           "label": "Description text for adding a word to a collection. (without search)",

--- a/h5p-bildetema/language/da.json
+++ b/h5p-bildetema/language/da.json
@@ -250,7 +250,7 @@
         },
         {
           "label": "Description text for adding a word to a collection",
-          "default": "Tilføj ord ved at klikke på bogmærket på billederne, enten via {{search}} eller {{topicView}}."
+          "default": "Tilføj ord via {{search}} eller {{topicView}}. Klik på bogmærket på billederne."
         },
         {
           "label": "Description text for adding a word to a collection. (without search)",

--- a/h5p-bildetema/language/da.json
+++ b/h5p-bildetema/language/da.json
@@ -221,6 +221,10 @@
           "default": "Afbestille"
         },
         {
+          "label": "Confirm",
+          "default": "Okay"
+        },
+        {
           "label": "Aria text for disabled button in choose a collection dialog",
           "default": "Vælg en samling"
         },

--- a/h5p-bildetema/language/is.json
+++ b/h5p-bildetema/language/is.json
@@ -250,7 +250,7 @@
         },
         {
           "label": "Description text for adding a word to a collection",
-          "default": "Bættu orðum við með því að smella á bókamerkið á myndunum, annaðhvort í gegnum {{search}} eða {{topicView}}."
+          "default": "Bættu við orðum með {{search}} eða {{topicView}}. Smelltu á bókamerkið á myndunum."
         },
         {
           "label": "Description text for adding a word to a collection. (without search)",

--- a/h5p-bildetema/language/is.json
+++ b/h5p-bildetema/language/is.json
@@ -221,6 +221,10 @@
           "default": "Hætta við"
         },
         {
+          "label": "Confirm",
+          "default": "Staðfesta"
+        },
+        {
           "label": "Aria text for disabled button in choose a collection dialog",
           "default": "Veldu safn"
         },

--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -221,6 +221,10 @@
           "default": "Avbryt"
         },
         {
+          "label": "Confirm",
+          "default": "Ok"
+        },
+        {
           "label": "Aria text for disabled button in choose a collection dialog",
           "default": "Velg en samling"
         },

--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -250,7 +250,7 @@
         },
         {
           "label": "Description text for adding a word to a collection",
-          "default": "Legg til ord ved å klikke på bokmerket på bildene, enten via {{search}} eller {{topicView}}."
+          "default": "Legg til ord via {{search}} eller {{topicView}}. Klikk på bokmerket på bildene."
         },
         {
           "label": "Description text for adding a word to a collection. (without search)",

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -250,7 +250,7 @@
         },
         {
           "label": "Description text for adding a word to a collection",
-          "default": "Legg til ord ved å klikke på bokmerket på bileta, anten via {{search}} eller {{topicView}}."
+          "default": "Legg til ord via {{search}} eller {{topicView}}. Klikk på bokmerket på bileta."
         },
         {
           "label": "Description text for adding a word to a collection. (without search)",

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -221,6 +221,10 @@
           "default": "Avbryt"
         },
         {
+          "label": "Confirm",
+          "default": "Ok"
+        },
+        {
           "label": "Aria text for disabled button in choose a collection dialog",
           "default": "Vel ei samling"
         },

--- a/h5p-bildetema/language/sv.json
+++ b/h5p-bildetema/language/sv.json
@@ -250,7 +250,7 @@
         },
         {
           "label": "Description text for adding a word to a collection",
-          "default": "Lägg till ord genom att klicka på bokmärket på bilderna, antingen via {{search}} eller {{topicView}}."
+          "default": "Lägg till ord via {{search}} eller {{topicView}}. Klicka på bokmärket på bilderna."
         },
         {
           "label": "Description text for adding a word to a collection. (without search)",

--- a/h5p-bildetema/language/sv.json
+++ b/h5p-bildetema/language/sv.json
@@ -221,6 +221,10 @@
           "default": "Avbryt"
         },
         {
+          "label": "Confirm",
+          "default": "Ok"
+        },
+        {
           "label": "Aria text for disabled button in choose a collection dialog",
           "default": "Välj en samling"
         },

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 249,
+  "patchVersion": 250,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -331,6 +331,12 @@
         "type": "text"
       },
       {
+        "label": "Confirm",
+        "name": "confirm",
+        "default": "Ok",
+        "type": "text"
+      },
+      {
         "label": "Aria text for disabled button in choose a collection dialog",
         "name": "ariaDisabledChooseACollection",
         "default": "Choose a collection",

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -375,7 +375,7 @@
       {
         "label": "Description text for adding a word to a collection",
         "name": "addWordsDescription",
-        "default": "Add words by clicking on the bookmark on the images, either via {{search}} or {{topicView}}.",
+        "default": "Add words via {{search}} or {{topicView}}. Click on the bookmark on the images.",
         "type": "text"
       },
       {

--- a/h5p-bildetema/semantics.json.d.ts
+++ b/h5p-bildetema/semantics.json.d.ts
@@ -375,7 +375,7 @@ declare const $defaultExport: [
 			{
 				label: "Description text for adding a word to a collection",
 				name: "addWordsDescription",
-				"default": "Add words by clicking on the bookmark on the images, either via {{search}} or {{topicView}}.",
+				"default": "Add words via {{search}} or {{topicView}}. Click on the bookmark on the images.",
 				type: "text"
 			},
 			{

--- a/h5p-bildetema/semantics.json.d.ts
+++ b/h5p-bildetema/semantics.json.d.ts
@@ -331,6 +331,12 @@ declare const $defaultExport: [
 				type: "text"
 			},
 			{
+				label: "Confirm",
+				name: "confirm",
+				"default": "Ok",
+				type: "text"
+			},
+			{
 				label: "Aria text for disabled button in choose a collection dialog",
 				name: "ariaDisabledChooseACollection",
 				"default": "Choose a collection",

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -182,11 +182,11 @@ export const Bildetema: FC<BildetemaProps> = ({
 
           <Route
             path={`${STATIC_PATH.COLLECTIONS}`}
-            element={<CollectionsController rtl={directionRtl} />}
+            element={<CollectionsController />}
           />
           <Route
             path={`${STATIC_PATH.COLLECTIONS}/:collection`}
-            element={<CollectionsController rtl={directionRtl} />}
+            element={<CollectionsController />}
           />
         </>
         <Route path="*" element={<Navigate to={`/${defaultLanguages[0]}`} />} />

--- a/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/h5p-bildetema/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -3,8 +3,9 @@ import { LanguageCode } from "common/types/LanguageCode";
 import { CurrentTopics } from "common/types/types";
 import { labelToUrlComponent } from "common/utils/string.utils";
 import { FC, ReactPortal } from "react";
-import { Link } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useNewDBContext } from "common/hooks/useNewDBContext";
+import { STATIC_PATH } from "common/constants/paths";
 import {
   BackIcon,
   BreadcrumbsArrowIcon,
@@ -32,8 +33,14 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
   currentLanguageCode,
   currentTopics,
 }) => {
+  const { pathname } = useLocation();
   const lang = useSiteLanguageString();
-  const currentLang = useCurrentLanguageAttribute();
+  const currentLangAttribute = useCurrentLanguageAttribute();
+  const currentLang =
+    pathname.startsWith(STATIC_PATH.COLLECTIONS) ||
+    pathname.startsWith(STATIC_PATH.SEARCH)
+      ? lang
+      : currentLangAttribute;
   const { translations } = useNewDBContext();
   const labelFromDb = getLabelFromTranslationRecord(
     currentLanguageCode,
@@ -128,7 +135,7 @@ export const Breadcrumbs: FC<BreadcrumbsProps> = ({
                 </span>
                 {homePageBreadCrumb ? (
                   <span className={styles.homeButton}>
-                    <span className={styles.homeIcon}>
+                    <span className={styles.homeIcon} aria-hidden="true">
                       <HomeIcon />
                     </span>
                     <span className={styles.visuallyHidden} lang={lang}>

--- a/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
@@ -14,13 +14,7 @@ import useCurrentCollection from "../../hooks/useCurrentCollection";
 import { useL10ns } from "../../hooks/useL10n";
 import { H5PWrapper } from "../../h5p/H5PWrapper";
 
-type CollectionControllerProps = {
-  rtl?: boolean;
-};
-
-const CollectionController = ({
-  rtl = false,
-}: CollectionControllerProps): JSX.Element => {
+const CollectionController = (): JSX.Element => {
   const h5pInstance = useH5PInstance<H5PWrapper>();
   const langCode = useCurrentLanguageCode();
   const words = useSelectedWords();
@@ -85,7 +79,7 @@ const CollectionController = ({
         <SubHeader
           breadCrumbs={breadCrumbs}
           isWordView={!!collection && words.length > 0}
-          rtl={rtl}
+          rtl={false}
           showArticlesToggle={showArticlesToggle}
           includeShareButton
           includeSaveButton={!isCollectionOwner}

--- a/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionController.tsx
@@ -15,11 +15,11 @@ import { useL10ns } from "../../hooks/useL10n";
 import { H5PWrapper } from "../../h5p/H5PWrapper";
 
 type CollectionControllerProps = {
-  rtl: boolean;
+  rtl?: boolean;
 };
 
 const CollectionController = ({
-  rtl,
+  rtl = false,
 }: CollectionControllerProps): JSX.Element => {
   const h5pInstance = useH5PInstance<H5PWrapper>();
   const langCode = useCurrentLanguageCode();

--- a/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.module.scss
@@ -33,29 +33,6 @@
   }
 }
 
-.editDialog {
-  display: flex;
-  flex-direction: column;
-  gap: 2rem;
-  margin-top: 0.5rem;
-  & span {
-    font-size: $font-size-20;
-  }
-  & div {
-    display: flex;
-    gap: 1rem;
-  }
-  & button {
-    flex: 1;
-  }
-}
-
-.dialogButton {
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .menuButton {
   position: absolute;
   right: 1.5rem;

--- a/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
@@ -96,11 +96,11 @@ const CollectionElement = ({
         open={openDialog === OpenDialog.EDIT_DIALOG}
         onClose={() => setOpenDialog(OpenDialog.NONE)}
         title={changeName}
-        description={nameOfTheCollection}
       >
         <div className={styles.editDialog}>
           <TextInput
             handleChange={handleEditCollectionTitle}
+            label={nameOfTheCollection}
             value={title}
             handleEnter={handleNewTitle}
           />

--- a/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
@@ -2,8 +2,6 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { useMyCollections } from "common/hooks/useMyCollections";
 import { Button } from "common/components/Button";
-import Dialog from "common/components/Dialog/Dialog";
-import TextInput from "common/components/TextInput/TextInput";
 import {
   DeleteIcon,
   EditIcon,
@@ -12,6 +10,7 @@ import {
 import { Menu, MenuButton, MenuItem, MenuItems } from "../../Menu";
 import styles from "./CollectionElement.module.scss";
 import DeleteDialog from "../../DeleteDialog/DeleteDialog";
+import EditDialog from "../../EditDialog/EditDialog";
 import { useL10ns } from "../../../hooks/useL10n";
 
 const OpenDialog = {
@@ -41,8 +40,6 @@ const CollectionElement = ({
   const {
     changeName,
     delete: l10nDelete,
-    cancel,
-    saveChanges,
     nameOfTheCollection,
     deleteCollection: l10nDeleteCollection,
     deleteCollectionConfirmation,
@@ -50,8 +47,6 @@ const CollectionElement = ({
   } = useL10ns(
     "changeName",
     "delete",
-    "cancel",
-    "saveChanges",
     "nameOfTheCollection",
     "deleteCollection",
     "deleteCollectionConfirmation",
@@ -76,6 +71,11 @@ const CollectionElement = ({
     setOpenDialog(OpenDialog.NONE);
   };
 
+  const handleCancelEditDialog = (): void => {
+    setOpenDialog(OpenDialog.NONE);
+    setTitle(label);
+  };
+
   return (
     <div className={styles.collectionElementWrapper}>
       <span className={styles.label}>
@@ -92,36 +92,15 @@ const CollectionElement = ({
         onClose={() => setOpenDialog(OpenDialog.NONE)}
         onDelete={handleDeleteCollection}
       />
-      <Dialog
+      <EditDialog
         open={openDialog === OpenDialog.EDIT_DIALOG}
-        onClose={() => setOpenDialog(OpenDialog.NONE)}
         title={changeName}
-      >
-        <div className={styles.editDialog}>
-          <TextInput
-            handleChange={handleEditCollectionTitle}
-            label={nameOfTheCollection}
-            value={title}
-            handleEnter={handleNewTitle}
-          />
-          <div>
-            <Button
-              className={styles.dialogButton}
-              variant="secondary"
-              onClick={() => setOpenDialog(OpenDialog.NONE)}
-            >
-              {cancel}
-            </Button>
-            <Button
-              className={styles.dialogButton}
-              variant="default"
-              onClick={handleNewTitle}
-            >
-              {saveChanges}
-            </Button>
-          </div>
-        </div>
-      </Dialog>
+        textInputValue={title}
+        textInputLabel={nameOfTheCollection}
+        onTextInputChange={handleEditCollectionTitle}
+        onClose={handleCancelEditDialog}
+        onSave={handleNewTitle}
+      />
       <Menu>
         <MenuButton className={styles.menuButton}>
           <Button variant="circle" aria-label={moreOptionsAriaLabel}>

--- a/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
@@ -5,6 +5,7 @@ import { Button } from "common/components/Button";
 import {
   DeleteIcon,
   EditIcon,
+  LinkIcon,
   MoreVertIcon,
 } from "common/components/Icons/Icons";
 import { Menu, MenuButton, MenuItem, MenuItems } from "../../Menu";
@@ -12,6 +13,7 @@ import styles from "./CollectionElement.module.scss";
 import DeleteDialog from "../../DeleteDialog/DeleteDialog";
 import EditDialog from "../../EditDialog/EditDialog";
 import { useL10ns } from "../../../hooks/useL10n";
+import { getSiteLanguagePath } from "../../../hooks/useSiteLanguage";
 
 const OpenDialog = {
   DELETE_DIALOG: "DELETE_DIALOG",
@@ -36,6 +38,7 @@ const CollectionElement = ({
   const [openDialog, setOpenDialog] = React.useState<OpenDialog>(
     OpenDialog.NONE,
   );
+  const siteLanguagePath = getSiteLanguagePath();
   const { deleteCollection, changeCollectionTitle } = useMyCollections();
   const {
     changeName,
@@ -44,6 +47,7 @@ const CollectionElement = ({
     deleteCollection: l10nDeleteCollection,
     deleteCollectionConfirmation,
     moreOptionsAriaLabel,
+    copyLink,
   } = useL10ns(
     "changeName",
     "delete",
@@ -51,6 +55,7 @@ const CollectionElement = ({
     "deleteCollection",
     "deleteCollectionConfirmation",
     "moreOptionsAriaLabel",
+    "copyLink",
   );
 
   const [title, setTitle] = useState(label);
@@ -74,6 +79,21 @@ const CollectionElement = ({
   const handleCancelEditDialog = (): void => {
     setOpenDialog(OpenDialog.NONE);
     setTitle(label);
+  };
+
+  const handleCopyLink = async (): Promise<void> => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const { origin } = window.location;
+    const language = siteLanguagePath ? `/${siteLanguagePath}` : "";
+    const url = `${origin}${language}/#${href}`;
+
+    try {
+      await navigator.clipboard.writeText(url);
+    } catch (error) {
+      /* TODO: Show error message to user in for example a toast */
+    }
   };
 
   return (
@@ -112,6 +132,11 @@ const CollectionElement = ({
             label={changeName}
             icon={<EditIcon />}
             onClick={() => setOpenDialog(OpenDialog.EDIT_DIALOG)}
+          />
+          <MenuItem
+            label={copyLink}
+            icon={<LinkIcon />}
+            onClick={handleCopyLink}
           />
           <MenuItem
             label={l10nDelete}

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.module.scss
@@ -12,6 +12,9 @@ $gap: $spacing--24;
   padding: 0;
   width: 100%;
 
+  // TODO: Change to grid-template-columns if direction is not important
+  // Currently this mimics the grid size on the search page
+
   [class*="rtl"] & {
     justify-content: flex-end;
   }
@@ -22,15 +25,15 @@ $gap: $spacing--24;
     margin: 0;
     width: 100%;
 
-    @include breakpoint-min(700px) {
+    @include breakpoint-min(656px) {
       width: calc((100% - #{$gap}) / 2);
     }
 
-    @include breakpoint-min(1040px) {
+    @include breakpoint-min(980px) {
       width: calc((100% - (#{$gap} * 2)) / 3);
     }
 
-    @include breakpoint-min(1390px) {
+    @include breakpoint-min(1304px) {
       width: calc((100% - (#{$gap} * 3)) / 4);
     }
   }

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-redundant-roles */
 import { useNavigate, Link } from "react-router-dom";
 import { Button } from "common/components/Button";
 import { STATIC_PATH } from "common/constants/paths";
@@ -99,7 +100,7 @@ const CollectionPage = ({
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.words}>
+      <ul role="list" className={styles.words}>
         {words.map(word => (
           <MultiLanguageWord
             key={word.id}
@@ -108,7 +109,7 @@ const CollectionPage = ({
             showArticles={showArticles}
           />
         ))}
-      </div>
+      </ul>
       {isCollectionOwner ? (
         <p className={styles.description}>{descriptionWithLinks}</p>
       ) : null}

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
@@ -7,7 +7,6 @@
 }
 
 .dialogContentWrapper {
-  margin-top: 0.5rem;
   display: flex;
   flex-direction: column;
   gap: 2rem;

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.module.scss
@@ -38,4 +38,10 @@
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
+  margin: 0;
+  padding: 0;
+
+  li {
+    list-style: none;
+  }
 }

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-redundant-roles */
 import React, { useMemo, useState } from "react";
 import { useMyCollections } from "common/hooks/useMyCollections";
 import { STATIC_PATH } from "common/constants/paths";
@@ -63,19 +64,20 @@ const CollectionsPage = (): React.JSX.Element => {
         <AddIcon />
         <span>{createACollection}</span>
       </Button>
-      <div className={styles.collectionWrapper}>
+      <ul role="list" className={styles.collectionWrapper}>
         {reversedCollections.map(v => (
-          <CollectionElement
-            key={v?.id}
-            id={v.id}
-            amountOfCollectionItems={v.wordsIds.length}
-            label={v.title}
-            href={`${STATIC_PATH.COLLECTIONS}/${v.title}?lang=${langCode}&id=${
-              v.id
-            }${v.wordsIds.length > 0 ? `&words=${v.wordsIds}` : ""}`}
-          />
+          <li role="listitem">
+            <CollectionElement
+              key={v?.id}
+              id={v.id}
+              amountOfCollectionItems={v.wordsIds.length}
+              label={v.title}
+              href={`${STATIC_PATH.COLLECTIONS}/${v.title}?lang=${langCode}&id=${v.id
+                }${v.wordsIds.length > 0 ? `&words=${v.wordsIds}` : ""}`}
+            />
+          </li>
         ))}
-      </div>
+      </ul>
     </div>
   );
 };

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
@@ -52,7 +52,6 @@ const CollectionsPage = (): React.JSX.Element => {
     <div className={styles.container}>
       <Dialog
         title={createACollection}
-        description={nameOfTheCollection}
         open={createCollectionDialogOpen}
         onClose={() => setCreateCollectionDialogOpen(false)}
       >
@@ -60,6 +59,7 @@ const CollectionsPage = (): React.JSX.Element => {
           <TextInput
             handleChange={(e: string) => setTextInput(e)}
             handleEnter={handleCreateNewCollection}
+            label={nameOfTheCollection}
             value={textInput}
           />
           <div className={styles.dialogButtonWrapper}>

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
@@ -2,27 +2,21 @@ import React, { useMemo, useState } from "react";
 import { useMyCollections } from "common/hooks/useMyCollections";
 import { STATIC_PATH } from "common/constants/paths";
 import { Button } from "common/components/Button";
-import TextInput from "common/components/TextInput/TextInput";
-import Dialog from "common/components/Dialog/Dialog";
 import { AddIcon } from "common/components/Icons/Icons";
 import { useNavigate } from "react-router-dom";
 import styles from "./CollectionsPage.module.scss";
 import CollectionElement from "../CollectionElement/CollectionElement";
 import { useCurrentLanguageCode } from "../../../hooks/useCurrentLanguage";
 import { useL10ns } from "../../../hooks/useL10n";
+import EditDialog from "../../EditDialog/EditDialog";
 
 const CollectionsPage = (): React.JSX.Element => {
-  const {
-    nameOfTheCollection,
-    createACollection,
-    collectionsPageDescription,
-    cancel,
-  } = useL10ns(
-    "nameOfTheCollection",
-    "createACollection",
-    "collectionsPageDescription",
-    "cancel",
-  );
+  const { nameOfTheCollection, createACollection, collectionsPageDescription } =
+    useL10ns(
+      "nameOfTheCollection",
+      "createACollection",
+      "collectionsPageDescription",
+    );
 
   const langCode = useCurrentLanguageCode();
   const navigate = useNavigate();
@@ -50,31 +44,16 @@ const CollectionsPage = (): React.JSX.Element => {
   };
   return (
     <div className={styles.container}>
-      <Dialog
-        title={createACollection}
+      <EditDialog
         open={createCollectionDialogOpen}
+        title={createACollection}
+        textInputValue={textInput}
+        textInputLabel={nameOfTheCollection}
+        createNewCollection
+        onTextInputChange={(e: string) => setTextInput(e)}
         onClose={() => setCreateCollectionDialogOpen(false)}
-      >
-        <div className={styles.dialogContentWrapper}>
-          <TextInput
-            handleChange={(e: string) => setTextInput(e)}
-            handleEnter={handleCreateNewCollection}
-            label={nameOfTheCollection}
-            value={textInput}
-          />
-          <div className={styles.dialogButtonWrapper}>
-            <Button
-              variant="secondary"
-              onClick={() => setCreateCollectionDialogOpen(false)}
-            >
-              {cancel}
-            </Button>
-            <Button variant="default" onClick={handleCreateNewCollection}>
-              Ok
-            </Button>
-          </div>
-        </div>
-      </Dialog>
+        onSave={handleCreateNewCollection}
+      />
       <p className={styles.description}>{collectionsPageDescription}</p>
       <Button
         className={styles.addButton}

--- a/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionsPage/CollectionsPage.tsx
@@ -72,8 +72,9 @@ const CollectionsPage = (): React.JSX.Element => {
               id={v.id}
               amountOfCollectionItems={v.wordsIds.length}
               label={v.title}
-              href={`${STATIC_PATH.COLLECTIONS}/${v.title}?lang=${langCode}&id=${v.id
-                }${v.wordsIds.length > 0 ? `&words=${v.wordsIds}` : ""}`}
+              href={`${STATIC_PATH.COLLECTIONS}/${v.title}?lang=${langCode}&id=${
+                v.id
+              }${v.wordsIds.length > 0 ? `&words=${v.wordsIds}` : ""}`}
             />
           </li>
         ))}

--- a/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.module.scss
@@ -25,8 +25,9 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 0.5rem 0.25rem;
+  padding: 0 0.25rem 0.5rem;
 }
+
 .translation {
   display: flex;
   flex-direction: column;

--- a/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.module.scss
@@ -25,7 +25,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding: 0.5rem 0;
+  padding: 0.5rem 0.25rem;
 }
 .translation {
   display: flex;

--- a/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/MultiLanguageWord/MultiLanguageWord.tsx
@@ -21,7 +21,10 @@ import { useL10ns, useL10n } from "../../../hooks/useL10n";
 import styles from "./MultiLanguageWord.module.scss";
 import { translatedLabel } from "../../../utils/language.utils";
 import DeleteDialog from "../../DeleteDialog/DeleteDialog";
-import { useCurrentLanguageCode } from "../../../hooks/useCurrentLanguage";
+import {
+  getLanguageAttribute,
+  useCurrentLanguageCode,
+} from "../../../hooks/useCurrentLanguage";
 import { Menu, MenuItem, MenuItems, MenuButton } from "../../Menu";
 import useCurrentCollection from "../../../hooks/useCurrentCollection";
 
@@ -235,6 +238,7 @@ export const MultiLanguageWord = ({
                   : ""
               }
               lang={lang}
+              labelLang={getLanguageAttribute(translation.lang.code)}
               playAudioLabel={playAudioLabel}
               stopAudioLabel={stopAudioLabel}
               audioFiles={translation.audioFiles}

--- a/h5p-bildetema/src/components/EditDialog/EditDialog.module.scss
+++ b/h5p-bildetema/src/components/EditDialog/EditDialog.module.scss
@@ -1,0 +1,13 @@
+@use "common/abstracts" as *;
+
+.dialogButtonWrapper {
+  display: flex;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+.dialogButton {
+  display: flex;
+  flex: 1;
+  justify-content: center;
+}

--- a/h5p-bildetema/src/components/EditDialog/EditDialog.tsx
+++ b/h5p-bildetema/src/components/EditDialog/EditDialog.tsx
@@ -1,0 +1,76 @@
+import Dialog from "common/components/Dialog/Dialog";
+import TextInput from "common/components/TextInput/TextInput";
+import { Button } from "common/components/Button/Button";
+import { useL10ns } from "../../hooks/useL10n";
+import styles from "./EditDialog.module.scss";
+
+type EditDialogProps = {
+  open: boolean;
+  title: string;
+  description?: string;
+  textInputLabel: string;
+  textInputValue: string;
+  createNewCollection?: boolean;
+  onTextInputChange: (value: string) => void;
+  onClose: () => void;
+  onSave: () => void;
+};
+
+const EditDialog = ({
+  open,
+  title,
+  description,
+  textInputValue,
+  textInputLabel,
+  createNewCollection = false,
+  onTextInputChange,
+  onClose,
+  onSave,
+}: EditDialogProps): JSX.Element => {
+  const { cancel, confirm, saveChanges, ariaDisabledCreateACollection } =
+    useL10ns(
+      "cancel",
+      "confirm",
+      "saveChanges",
+      "ariaDisabledCreateACollection",
+    );
+
+  const saveButtonText = createNewCollection ? confirm : saveChanges;
+  const noValidInput = !textInputValue.trim();
+
+  return (
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={title}
+      description={description}
+    >
+      <TextInput
+        handleChange={onTextInputChange}
+        handleEnter={onSave}
+        label={textInputLabel}
+        value={textInputValue}
+      />
+      <div className={styles.dialogButtonWrapper}>
+        <Button
+          className={styles.dialogButton}
+          variant="secondary"
+          onClick={onClose}
+        >
+          {cancel}
+        </Button>
+        <Button
+          className={styles.dialogButton}
+          variant="default"
+          onClick={onSave}
+          aria-disabled={noValidInput}
+          disabledTooltip={ariaDisabledCreateACollection}
+        >
+          {saveButtonText}
+        </Button>
+      </div>
+    </Dialog>
+  );
+};
+
+export default EditDialog;

--- a/h5p-bildetema/src/components/Menu/Menu.module.scss
+++ b/h5p-bildetema/src/components/Menu/Menu.module.scss
@@ -27,4 +27,8 @@
   &[data-focus] {
     background-color: $beige;
   }
+
+  span {
+    display: flex;
+  }
 }

--- a/h5p-bildetema/src/components/Menu/Menu.tsx
+++ b/h5p-bildetema/src/components/Menu/Menu.tsx
@@ -50,7 +50,7 @@ export const MenuItem = forwardRef<HTMLElement, MenuItemProps>(
   ({ label, icon, onClick, ...props }, ref) => (
     <HMenuItem {...props} ref={ref}>
       <Button onClick={onClick} className={styles.menuItemButton}>
-        {icon}
+        <span aria-hidden="true">{icon}</span>
         {label}
       </Button>
     </HMenuItem>

--- a/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchFilter/SearchFilterDialog.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable jsx-a11y/no-redundant-roles */
 import { useMemo, useState } from "react";
 import { Button } from "common/components/Button";
 import { useNewDBContext } from "common/hooks/useNewDBContext";
@@ -81,9 +82,13 @@ const SearchFilterDialog = ({
               </button>
             </DialogTitle>
             <div className={styles.searchFilterWrapper}>
-              <ul className={styles.searchFilter}>
+              <ul role="list" className={styles.searchFilter}>
                 {topics?.map(topic => (
-                  <li key={topic.id} className={styles.checkBoxWrapper}>
+                  <li
+                    role="listitem"
+                    key={topic.id}
+                    className={styles.checkBoxWrapper}
+                  >
                     <FilterCheckbox
                       key={topic.id}
                       id={topic.id}

--- a/h5p-bildetema/src/components/SearchPage/SearchInput/SearchInput.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchInput/SearchInput.tsx
@@ -8,7 +8,7 @@ export type SearchInputProps = {
   search: string;
   placeholder?: string;
   rtl?: boolean;
-  lang?: string;
+  langAttribute?: string;
 };
 
 const SearchInput = ({
@@ -16,7 +16,7 @@ const SearchInput = ({
   search,
   placeholder,
   rtl,
-  lang,
+  langAttribute,
 }: SearchInputProps): JSX.Element => {
   const ref = useRef<HTMLInputElement>(null);
   const { searchInputLabel } = useL10ns("searchInputLabel");
@@ -37,7 +37,7 @@ const SearchInput = ({
           ref={ref}
           id={styles.searchInput}
           type="search"
-          lang={lang}
+          lang={langAttribute}
           className={`${styles.searchInput} ${rtl ? styles.rtl : ""}`}
           placeholder={placeholder ?? ""}
           value={search}

--- a/h5p-bildetema/src/components/SearchPage/SearchInput/SearchInput.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchInput/SearchInput.tsx
@@ -8,6 +8,7 @@ export type SearchInputProps = {
   search: string;
   placeholder?: string;
   rtl?: boolean;
+  lang?: string;
 };
 
 const SearchInput = ({
@@ -15,6 +16,7 @@ const SearchInput = ({
   search,
   placeholder,
   rtl,
+  lang,
 }: SearchInputProps): JSX.Element => {
   const ref = useRef<HTMLInputElement>(null);
   const { searchInputLabel } = useL10ns("searchInputLabel");
@@ -35,6 +37,7 @@ const SearchInput = ({
           ref={ref}
           id={styles.searchInput}
           type="search"
+          lang={lang}
           className={`${styles.searchInput} ${rtl ? styles.rtl : ""}`}
           placeholder={placeholder ?? ""}
           value={search}

--- a/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.module.scss
+++ b/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.module.scss
@@ -33,7 +33,7 @@
   display: flex;
   flex-direction: column;
   gap: 1rem;
-  padding-bottom: 0.5rem;
+  padding: 0 0.25rem 0.5rem;
 }
 
 .translation {

--- a/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchResultCard/SearchResultCard.tsx
@@ -19,6 +19,7 @@ import { useMyCollections } from "common/hooks/useMyCollections";
 import { useL10ns, useL10n } from "../../../hooks/useL10n";
 import styles from "./SearchResultCard.module.scss";
 import { translatedLabel } from "../../../utils/language.utils";
+import { getLanguageAttribute } from "../../../hooks/useCurrentLanguage";
 
 type SearchResultCardProps = {
   searchResult: SearchResult;
@@ -143,6 +144,7 @@ export const SearchResultCard = ({
             <Audio
               label={toSingleLabel(translation.labels)}
               lang={lang}
+              labelLang={getLanguageAttribute(translation.lang.code)}
               playAudioLabel={playAudioLabel}
               stopAudioLabel={stopAudioLabel}
               audioFiles={translation.audioFiles}

--- a/h5p-bildetema/src/components/SearchPage/SearchResultView/SearchResultView.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchResultView/SearchResultView.tsx
@@ -108,7 +108,6 @@ const SearchResultView = ({
   return (
     <div className={styles.searchResultView}>
       <div className={styles.searchViewHeading}>
-        <p className={styles.searchResultLabel}>{getSearchResultLabel()}</p>
         <div className={styles.buttonWrapper}>
           <SearchFilterDialog
             handleFilterChange={handleFilterChange}
@@ -116,6 +115,7 @@ const SearchResultView = ({
             resetFilter={resetFilter}
           />
         </div>
+        <p className={styles.searchResultLabel}>{getSearchResultLabel()}</p>
         {/* TODO REMOVE ? */}
         {/* <div className={styles.orderWrap}>
           <span>Sorter etter</span>

--- a/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
@@ -3,7 +3,10 @@ import { STATIC_PATH } from "common/constants/paths";
 import SearchInput from "../SearchInput/SearchInput";
 import Select, { OptionType } from "../../Select/Select";
 import { Breadcrumbs } from "../../Breadcrumbs/Breadcrumbs";
-import { useCurrentLanguage } from "../../../hooks/useCurrentLanguage";
+import {
+  getLanguageAttribute,
+  useCurrentLanguage,
+} from "../../../hooks/useCurrentLanguage";
 import { useL10ns } from "../../../hooks/useL10n";
 import styles from "./SearchView.module.scss";
 
@@ -65,6 +68,7 @@ const SearchView = ({
             search={search}
             placeholder={searchInputPlaceholder}
             rtl={isRtl}
+            lang={getLanguageAttribute(searchLanguage.code)}
           />
           <Select
             options={languages}

--- a/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
+++ b/h5p-bildetema/src/components/SearchPage/SearchView/SearchView.tsx
@@ -68,7 +68,7 @@ const SearchView = ({
             search={search}
             placeholder={searchInputPlaceholder}
             rtl={isRtl}
-            lang={getLanguageAttribute(searchLanguage.code)}
+            langAttribute={getLanguageAttribute(searchLanguage.code)}
           />
           <Select
             options={languages}

--- a/h5p-bildetema/src/hooks/useCurrentLanguage.ts
+++ b/h5p-bildetema/src/hooks/useCurrentLanguage.ts
@@ -30,6 +30,10 @@ export const useCurrentLanguageAttribute = (): string => {
   return attributeLanguages[currentLanguageCode];
 };
 
+export const getLanguageAttribute = (langCode: LanguageCode): string => {
+  return attributeLanguages[langCode];
+};
+
 export const useCurrentLanguage = (): Language => {
   const { langCodeTolanguages } = useNewDBContext();
   const langCode = useCurrentLanguageCode();

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 105,
+  "patchVersion": 106,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json.d.ts
+++ b/h5p-editor-bildetema-words-topic-image/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "Bildetema Words Topic Image Editor";
 export const machineName : "H5PEditor.BildetemaWordsTopicImage";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 105;
+export const patchVersion : 106;
 export const runnable : 0;
 export const preloadedJs : [
 	{

--- a/h5p-editor-bildetema-words-topic-image/src/components/ColorButton/ColorButton.tsx
+++ b/h5p-editor-bildetema-words-topic-image/src/components/ColorButton/ColorButton.tsx
@@ -20,6 +20,7 @@ export const ColorButton: FC<ColorButtonProps> = ({
         selected ? styles.selected : ""
       }`}
       type="button"
+      aria-label={`Select color ${color}`}
     >
       {}
     </button>

--- a/h5p-editor-bildetema-words-topic-image/src/components/editor/Editor.tsx
+++ b/h5p-editor-bildetema-words-topic-image/src/components/editor/Editor.tsx
@@ -417,6 +417,7 @@ export const Editor: FC<EditorProps> = ({ image, words, initialHotspots }) => {
                   className={styles.button}
                   type="button"
                   onClick={moveHotspotUp}
+                  aria-label="Move up"
                 >
                   <ArrowIcon
                     transform="scale(0.9) rotate(180)"
@@ -427,6 +428,7 @@ export const Editor: FC<EditorProps> = ({ image, words, initialHotspots }) => {
                   className={styles.button}
                   type="button"
                   onClick={moveHotspotDown}
+                  aria-label="Move down"
                 >
                   <ArrowIcon transform="scale(0.9)" transformOrigin="50% 50%" />
                 </button>


### PR DESCRIPTION
- [x] Adds copy link option https://trello.com/c/JMxIVBko/459-legg-til-del-samling-i-oversikten-over-samlinger
- [x] Changes text in empty collection https://trello.com/c/BzsVWDQA/458-samling-endre-tekst-inne-i-tom-samling
- [x] Switches placement of filter and search result label mentioned in the latest comments in https://trello.com/c/czV2RVOp/456-flytte-knappen-filtrer-etter-tema-til-venstre-ved-siden-av-tekst

Also:
- Adds some accessibility improvements
- Creates a EditDialog component for editing and creating collection name
- Fixes use of lang attribute