### PR TITLE
fix: set font family for TextInput label

### DIFF
--- a/common/components/TextInput/TextInput.module.scss
+++ b/common/components/TextInput/TextInput.module.scss
@@ -21,5 +21,6 @@
 }
 
 .label {
+  font-family: sans-serif;
   font-size: $font-size-16;
 }

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 118,
+  "patchVersion": 119,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/library.json.d.ts
+++ b/h5p-bildetema-words-grid-view/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "H5P Bildetema Words Grid View";
 export const machineName : "H5P.BildetemaWordsGridView";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 118;
+export const patchVersion : 119;
 export const runnable : 1;
 export const preloadedJs : [
 	{

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 122,
+  "patchVersion": 123,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -253,10 +253,6 @@
           "default": "Add words via {{search}} or {{topicView}}. Click on the bookmark on the images."
         },
         {
-          "label": "Description text for adding a word to a collection. (without search)",
-          "default": "Add words by clicking on the bookmark on the images via {{topicView}}."
-        },
-        {
           "label": "Collections Page Description",
           "default": "Here you can save words in your own collections. The collections will only be stored in this browser. If you want to share the collection or view it elsewhere, you can copy the link to the collection."
         },

--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -265,10 +265,6 @@
           "default": "Choose a collection"
         },
         {
-          "label": "Choose collection",
-          "default": "Choose collection"
-        },
-        {
           "label": "Create new collection",
           "default": "Create new collection"
         },

--- a/h5p-bildetema/language/.en.json
+++ b/h5p-bildetema/language/.en.json
@@ -297,6 +297,10 @@
           "default": "Are you sure you want to delete the collection"
         },
         {
+          "label": "Delete collection status message",
+          "default": "{{collection}} was deleted"
+        },
+        {
           "label": "This collection is empty",
           "default": "This collection is empty"
         },

--- a/h5p-bildetema/language/da.json
+++ b/h5p-bildetema/language/da.json
@@ -297,6 +297,10 @@
           "default": "Er du sikker på at du vil slette samlingen"
         },
         {
+          "label": "Delete collection status message",
+          "default": "{{collection}} blev slettet"
+        },
+        {
           "label": "This collection is empty",
           "default": "Denne samling er tom"
         },

--- a/h5p-bildetema/language/da.json
+++ b/h5p-bildetema/language/da.json
@@ -253,10 +253,6 @@
           "default": "Tilføj ord via {{search}} eller {{topicView}}. Klik på bogmærket på billederne."
         },
         {
-          "label": "Description text for adding a word to a collection. (without search)",
-          "default": "Tilføj ord ved at klikke på bogmærket på billederne via {{topicView}}."
-        },
-        {
           "label": "Collections Page Description",
           "default": "Her kan du gemme ord i dine egne samlinger. Samlingerne vil kun blive gemt i denne browser. Hvis du vil dele samlingen eller se den andre steder, kan du kopiere linket til samlingen."
         },

--- a/h5p-bildetema/language/da.json
+++ b/h5p-bildetema/language/da.json
@@ -265,10 +265,6 @@
           "default": "Vælg en samling"
         },
         {
-          "label": "Choose collection",
-          "default": "Vælg samling"
-        },
-        {
           "label": "Create new collection",
           "default": "Opret ny samling"
         },

--- a/h5p-bildetema/language/is.json
+++ b/h5p-bildetema/language/is.json
@@ -253,10 +253,6 @@
           "default": "Bættu við orðum með {{search}} eða {{topicView}}. Smelltu á bókamerkið á myndunum."
         },
         {
-          "label": "Description text for adding a word to a collection. (without search)",
-          "default": "Bættu við orðum með því að smella á bókamerkið á myndunum í gegnum {{topicView}}."
-        },
-        {
           "label": "Collections Page Description",
           "default": "Hér getur þú vistað orð í þínum eigin söfnum. Söfnin verða aðeins geymd í þessum vafra. Ef þú vilt deila safninu eða skoða það annars staðar geturðu afritað hlekkinn á safnið."
         },

--- a/h5p-bildetema/language/is.json
+++ b/h5p-bildetema/language/is.json
@@ -297,6 +297,10 @@
           "default": "Ertu viss um að þú viljir eyða safninu"
         },
         {
+          "label": "Delete collection status message",
+          "default": "{{collection}} var eytt"
+        },
+        {
           "label": "This collection is empty",
           "default": "Þetta safn er tómt"
         },

--- a/h5p-bildetema/language/is.json
+++ b/h5p-bildetema/language/is.json
@@ -265,10 +265,6 @@
           "default": "Veldu safn"
         },
         {
-          "label": "Choose collection",
-          "default": "Veldu safn"
-        },
-        {
           "label": "Create new collection",
           "default": "Búðu til nýtt safn"
         },

--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -253,10 +253,6 @@
           "default": "Legg til ord via {{search}} eller {{topicView}}. Klikk på bokmerket på bildene."
         },
         {
-          "label": "Description text for adding a word to a collection. (without search)",
-          "default": "Legg til ord ved å klikke på bokmerket på bildene via {{topicView}}."
-        },
-        {
           "label": "Collections Page Description",
           "default": "Her kan du lagre ord i dine egne samlinger. Samlingene vil kun lagres i denne nettleseren. Om du ønsker å dele samlingen eller se den andre steder, kan du kopiere lenken til samlingen."
         },

--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -297,6 +297,10 @@
           "default": "Er du sikker på at du vil slette samlingen"
         },
         {
+          "label": "Delete collection status message",
+          "default": "{{collection}} ble slettet"
+        },
+        {
           "label": "This collection is empty",
           "default": "Denne samlingen er tom"
         },

--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -214,7 +214,7 @@
         },
         {
           "label": "Name of the collection",
-          "default": "Navnet på samlingen"
+          "default": "Navn på samlingen"
         },
         {
           "label": "Cancel",
@@ -263,10 +263,6 @@
         {
           "label": "Choose a collection",
           "default": "Velg en samling"
-        },
-        {
-          "label": "Choose collection",
-          "default": "Velg samling"
         },
         {
           "label": "Create new collection",

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -297,6 +297,10 @@
           "default": "Er du sikker på at du vil slette samlinga"
         },
         {
+          "label": "Delete collection status message",
+          "default": "{{collection}} vart sletta"
+        },
+        {
           "label": "This collection is empty",
           "default": "Denne samlinga er tom"
         },

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -265,10 +265,6 @@
           "default": "Vel ei samling"
         },
         {
-          "label": "Choose collection",
-          "default": "Vel samling"
-        },
-        {
           "label": "Create new collection",
           "default": "Opprett ny samling"
         },

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -253,10 +253,6 @@
           "default": "Legg til ord via {{search}} eller {{topicView}}. Klikk på bokmerket på bileta."
         },
         {
-          "label": "Description text for adding a word to a collection. (without search)",
-          "default": "Legg til ord ved å klikke på bokmerket på bileta via {{topicView}}."
-        },
-        {
           "label": "Collections Page Description",
           "default": "Her kan du lagra ord i dine eigne samlingar. Samlingane vil berre lagrast i denne nettlesaren. Om du ønskjer å dela samlinga eller sjå den andre stader, kan du kopiera lenkja til samlinga."
         },

--- a/h5p-bildetema/language/sv.json
+++ b/h5p-bildetema/language/sv.json
@@ -265,10 +265,6 @@
           "default": "Välj en samling"
         },
         {
-          "label": "Choose collection",
-          "default": "Välj samling"
-        },
-        {
           "label": "Create new collection",
           "default": "Skapa ny samling"
         },

--- a/h5p-bildetema/language/sv.json
+++ b/h5p-bildetema/language/sv.json
@@ -297,6 +297,10 @@
           "default": "Är du säker på att du vill radera samlingen"
         },
         {
+          "label": "Delete collection status message",
+          "default": "{{collection}} togs bort"
+        },
+        {
           "label": "This collection is empty",
           "default": "Denna samling är tom"
         },

--- a/h5p-bildetema/language/sv.json
+++ b/h5p-bildetema/language/sv.json
@@ -253,10 +253,6 @@
           "default": "Lägg till ord via {{search}} eller {{topicView}}. Klicka på bokmärket på bilderna."
         },
         {
-          "label": "Description text for adding a word to a collection. (without search)",
-          "default": "Lägg till ord genom att klicka på bokmärket på bilderna via {{topicView}}."
-        },
-        {
           "label": "Collections Page Description",
           "default": "Här kan du spara ord i dina egna samlingar. Samlingarna kommer endast att lagras i den här webbläsaren. Om du vill dela samlingen eller se den någon annanstans kan du kopiera länken till samlingen."
         },

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 250,
+  "patchVersion": 251,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -379,12 +379,6 @@
         "type": "text"
       },
       {
-        "label": "Description text for adding a word to a collection. (without search)",
-        "name": "addWordsDescriptionWithoutSearch",
-        "default": "Add words by clicking on the bookmark on the images via {{topicView}}.",
-        "type": "text"
-      },
-      {
         "label": "Collections Page Description",
         "name": "collectionsPageDescription",
         "default": "Here you can save words in your own collections. The collections will only be stored in this browser. If you want to share the collection or view it elsewhere, you can copy the link to the collection.",

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -445,6 +445,12 @@
         "type": "text"
       },
       {
+        "label": "Delete collection status message",
+        "name": "deleteCollectionStatusMessage",
+        "default": "{{collection}} was deleted",
+        "type": "text"
+      },
+      {
         "label": "This collection is empty",
         "name": "thisCollectionIsEmpty",
         "default": "This collection is empty",

--- a/h5p-bildetema/semantics.json
+++ b/h5p-bildetema/semantics.json
@@ -397,12 +397,6 @@
         "type": "text"
       },
       {
-        "label": "Choose collection",
-        "name": "chooseCollection",
-        "default": "Choose collection",
-        "type": "text"
-      },
-      {
         "label": "Create new collection",
         "name": "createNewCollection",
         "default": "Create new collection",

--- a/h5p-bildetema/semantics.json.d.ts
+++ b/h5p-bildetema/semantics.json.d.ts
@@ -445,6 +445,12 @@ declare const $defaultExport: [
 				type: "text"
 			},
 			{
+				label: "Delete collection status message",
+				name: "deleteCollectionStatusMessage",
+				"default": "{{collection}} was deleted",
+				type: "text"
+			},
+			{
 				label: "This collection is empty",
 				name: "thisCollectionIsEmpty",
 				"default": "This collection is empty",

--- a/h5p-bildetema/semantics.json.d.ts
+++ b/h5p-bildetema/semantics.json.d.ts
@@ -397,12 +397,6 @@ declare const $defaultExport: [
 				type: "text"
 			},
 			{
-				label: "Choose collection",
-				name: "chooseCollection",
-				"default": "Choose collection",
-				type: "text"
-			},
-			{
 				label: "Create new collection",
 				name: "createNewCollection",
 				"default": "Create new collection",

--- a/h5p-bildetema/semantics.json.d.ts
+++ b/h5p-bildetema/semantics.json.d.ts
@@ -379,12 +379,6 @@ declare const $defaultExport: [
 				type: "text"
 			},
 			{
-				label: "Description text for adding a word to a collection. (without search)",
-				name: "addWordsDescriptionWithoutSearch",
-				"default": "Add words by clicking on the bookmark on the images via {{topicView}}.",
-				type: "text"
-			},
-			{
 				label: "Collections Page Description",
 				name: "collectionsPageDescription",
 				"default": "Here you can save words in your own collections. The collections will only be stored in this browser. If you want to share the collection or view it elsewhere, you can copy the link to the collection.",

--- a/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
+++ b/h5p-bildetema/src/components/Bildetema/Bildetema.tsx
@@ -23,7 +23,6 @@ import {
   useCurrentLanguage,
   useCurrentLanguageCode,
 } from "../../hooks/useCurrentLanguage";
-import { environment, useEnvironment } from "../../hooks/useEnvironment";
 
 type BildetemaProps = {
   defaultLanguages: string[];
@@ -41,8 +40,6 @@ export const Bildetema: FC<BildetemaProps> = ({
     idToWords,
   } = useNewDBContext();
   const { pathname } = useLocation();
-  const env = useEnvironment();
-  const shouldIncludeSearch = env !== environment.prod;
 
   const [showLoadingLabel, setShowLoadingLabel] = useState(false);
   const isMobile = useMediaQuery({ query: "(max-width: 700px)" });
@@ -176,10 +173,7 @@ export const Bildetema: FC<BildetemaProps> = ({
         ))}
 
         <>
-          {shouldIncludeSearch && (
-            <Route path={`${STATIC_PATH.SEARCH}`} element={<SearchPage />} />
-          )}
-
+          <Route path={`${STATIC_PATH.SEARCH}`} element={<SearchPage />} />
           <Route
             path={`${STATIC_PATH.COLLECTIONS}`}
             element={<CollectionsController />}
@@ -192,7 +186,7 @@ export const Bildetema: FC<BildetemaProps> = ({
         <Route path="*" element={<Navigate to={`/${defaultLanguages[0]}`} />} />
       </Routes>
     );
-  }, [currTopics, defaultLanguages, directionRtl, shouldIncludeSearch]);
+  }, [currTopics, defaultLanguages, directionRtl]);
 
   const hiddenLanguageSelectors = STATIC_PATHS.includes(pathname);
 

--- a/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionElement/CollectionElement.tsx
@@ -8,6 +8,8 @@ import {
   LinkIcon,
   MoreVertIcon,
 } from "common/components/Icons/Icons";
+import { enqueueSnackbar } from "notistack";
+import { replacePlaceholders } from "common/utils/replacePlaceholders";
 import { Menu, MenuButton, MenuItem, MenuItems } from "../../Menu";
 import styles from "./CollectionElement.module.scss";
 import DeleteDialog from "../../DeleteDialog/DeleteDialog";
@@ -46,16 +48,22 @@ const CollectionElement = ({
     nameOfTheCollection,
     deleteCollection: l10nDeleteCollection,
     deleteCollectionConfirmation,
+    deleteCollectionStatusMessage,
     moreOptionsAriaLabel,
     copyLink,
+    linkCopied,
+    changesSaved,
   } = useL10ns(
     "changeName",
     "delete",
     "nameOfTheCollection",
     "deleteCollection",
     "deleteCollectionConfirmation",
+    "deleteCollectionStatusMessage",
     "moreOptionsAriaLabel",
     "copyLink",
+    "linkCopied",
+    "changesSaved",
   );
 
   const [title, setTitle] = useState(label);
@@ -68,12 +76,29 @@ const CollectionElement = ({
     if (title) {
       changeCollectionTitle({ newTitle: title, id });
       setOpenDialog(OpenDialog.NONE);
+      enqueueSnackbar(changesSaved, {
+        variant: "success",
+      });
     }
+  };
+
+  const getDeleteCollectionStatusMessage = (): React.ReactNode => {
+    const replacements = {
+      collection: <b key={1}>{label}</b>,
+    };
+    const message = replacePlaceholders(
+      deleteCollectionStatusMessage,
+      replacements,
+    );
+    return <span>{message}</span>;
   };
 
   const handleDeleteCollection = (): void => {
     deleteCollection(id);
     setOpenDialog(OpenDialog.NONE);
+    enqueueSnackbar(getDeleteCollectionStatusMessage(), {
+      variant: "success",
+    });
   };
 
   const handleCancelEditDialog = (): void => {
@@ -91,6 +116,9 @@ const CollectionElement = ({
 
     try {
       await navigator.clipboard.writeText(url);
+      enqueueSnackbar(linkCopied, {
+        variant: "success",
+      });
     } catch (error) {
       /* TODO: Show error message to user in for example a toast */
     }

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.module.scss
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.module.scss
@@ -52,16 +52,6 @@ $gap: $spacing--24;
   }
 }
 
-.bookmarkIcon {
-  border-radius: 50%;
-  fill: $dark-grey;
-  background-color: $beige;
-  padding: 0.5rem;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-}
-
 .navButtons {
   display: flex;
   gap: 2rem;

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
@@ -2,7 +2,6 @@
 import { useNavigate, Link } from "react-router-dom";
 import { Button } from "common/components/Button";
 import { STATIC_PATH } from "common/constants/paths";
-import { BookmarkIcon } from "common/components/Icons/Icons";
 import { replacePlaceholders } from "common/utils/replacePlaceholders";
 import { useSelectedWords } from "../../../hooks/useSelectedWords";
 import styles from "./CollectionPage.module.scss";
@@ -69,9 +68,6 @@ const CollectionPage = ({
   if (words.length === 0) {
     return (
       <div className={styles.container}>
-        <div className={styles.bookmarkIcon}>
-          <BookmarkIcon />
-        </div>
         <p className={styles.description}>{`${thisCollectionIsEmpty}.`}</p>
         <p className={styles.description}>{descriptionWithLinks}</p>
         <div className={styles.navButtons}>

--- a/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
+++ b/h5p-bildetema/src/components/CollectionsController/CollectionPage/CollectionPage.tsx
@@ -9,7 +9,6 @@ import { MultiLanguageWord } from "../MultiLanguageWord/MultiLanguageWord";
 import { useCurrentLanguage } from "../../../hooks/useCurrentLanguage";
 import useCurrentCollection from "../../../hooks/useCurrentCollection";
 import { useL10ns } from "../../../hooks/useL10n";
-import { useEnvironment, environment } from "../../../hooks/useEnvironment";
 
 type MyCollection = {
   showArticles: boolean;
@@ -24,11 +23,9 @@ const CollectionPage = ({
   const navigate = useNavigate();
   const lang = useCurrentLanguage();
   const { isCollectionOwner } = useCurrentCollection();
-  const env = useEnvironment();
 
   const {
     addWordsDescription,
-    addWordsDescriptionWithoutSearch,
     search,
     topicView,
     goToSearch,
@@ -36,15 +33,12 @@ const CollectionPage = ({
     thisCollectionIsEmpty,
   } = useL10ns(
     "addWordsDescription",
-    "addWordsDescriptionWithoutSearch",
     "search",
     "topicView",
     "goToSearch",
     "goToTopic",
     "thisCollectionIsEmpty",
   );
-
-  const shouldIncludeSearch = env !== environment.prod;
 
   const replacements = {
     search: (
@@ -59,11 +53,10 @@ const CollectionPage = ({
     ),
   };
 
-  const description = shouldIncludeSearch
-    ? addWordsDescription
-    : addWordsDescriptionWithoutSearch;
-
-  const descriptionWithLinks = replacePlaceholders(description, replacements);
+  const descriptionWithLinks = replacePlaceholders(
+    addWordsDescription,
+    replacements,
+  );
 
   if (words.length === 0) {
     return (
@@ -71,17 +64,13 @@ const CollectionPage = ({
         <p className={styles.description}>{`${thisCollectionIsEmpty}.`}</p>
         <p className={styles.description}>{descriptionWithLinks}</p>
         <div className={styles.navButtons}>
-          {shouldIncludeSearch && (
-            <Button
-              variant="default"
-              role="link"
-              onClick={() =>
-                navigate(`${STATIC_PATH.SEARCH}?lang=${lang.code}`)
-              }
-            >
-              {goToSearch}
-            </Button>
-          )}
+          <Button
+            variant="default"
+            role="link"
+            onClick={() => navigate(`${STATIC_PATH.SEARCH}?lang=${lang.code}`)}
+          >
+            {goToSearch}
+          </Button>
           <Button
             variant="default"
             role="link"

--- a/h5p-bildetema/src/components/Header/Header.tsx
+++ b/h5p-bildetema/src/components/Header/Header.tsx
@@ -19,7 +19,6 @@ import { OsloMetLogo } from "../Logos/Logos";
 import styles from "./Header.module.scss";
 import HeaderLink from "../HeaderLink/HeaderLink";
 import { useCurrentLanguageCode } from "../../hooks/useCurrentLanguage";
-import { environment, useEnvironment } from "../../hooks/useEnvironment";
 
 export type HeaderProps = {
   favLanguages: Language[];
@@ -38,7 +37,6 @@ export const Header: FC<HeaderProps> = ({
   hideLanguageSelectors,
   currentTopics,
 }) => {
-  const env = useEnvironment();
   const headerRef = useRef<HTMLDivElement>(null);
   const languageKeys = languages.map(
     lang => `lang_${lang}`,
@@ -58,8 +56,6 @@ export const Header: FC<HeaderProps> = ({
     "search",
     ...languageKeys,
   );
-
-  const shouldIncludeSearch = env !== environment.prod;
 
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const [langSelectorIsShown, setLangSelectorIsShown] = useState(false);
@@ -147,15 +143,11 @@ export const Header: FC<HeaderProps> = ({
               currentTopics={currentTopics}
             />
           )}
-
-          {shouldIncludeSearch && (
-            <HeaderLink
-              icon={<SearchIcon />}
-              label={l10nsSearch}
-              href={`${STATIC_PATH.SEARCH}?lang=${currentLanguageCode}`}
-            />
-          )}
-
+          <HeaderLink
+            icon={<SearchIcon />}
+            label={l10nsSearch}
+            href={`${STATIC_PATH.SEARCH}?lang=${currentLanguageCode}`}
+          />
           <HeaderLink
             label={myCollections}
             icon={<BookmarkIcon />}

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 106,
+  "patchVersion": 107,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json.d.ts
+++ b/h5p-editor-bildetema-words-topic-image/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "Bildetema Words Topic Image Editor";
 export const machineName : "H5PEditor.BildetemaWordsTopicImage";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 106;
+export const patchVersion : 107;
 export const runnable : 0;
 export const preloadedJs : [
 	{


### PR DESCRIPTION
Need to make sure the font-family is set on the label element. Wordpress sometimes removes some of the styling that is set.
<img width="423" alt="Skjermbilde 2024-09-30 kl  16 51 38" src="https://github.com/user-attachments/assets/0912083d-5daa-41af-8f00-80ce4dc4bd35">

Also:
- Removes the bookmark from an empty collection (was used to describe how to add words to the collection)
- Adds status message when a link to a collection is copied (from the overview page of the collections)
- Adds status message when a collection name is changed
- Adds status message when a collection is deleted
- Make sure search will be visible when deployed to production. Previously it has been discussed to only deploy collections and wait with search, but now they both will be deployed at the same time.
