### PR TITLE
feat: hide specific words from topic view

### DIFF
--- a/common/constants/search-only-words.ts
+++ b/common/constants/search-only-words.ts
@@ -1,6 +1,6 @@
 /**
- * Words that should only be visible on search page.
- * It includes ids of words that are duplicates of topic names
+ * Words that should only be found via the search page (not topic view). 
+ * The list includes ids of words that are duplicates of topic names 
  * that doesn't need to be shown in the topic view.
  */
 export const searchOnlyWords = [

--- a/common/constants/search-only-words.ts
+++ b/common/constants/search-only-words.ts
@@ -1,0 +1,28 @@
+/**
+ * Words that should only be visible on search page.
+ * It includes ids of words that are duplicates of topic names
+ * that doesn't need to be shown in the topic view.
+ */
+export const searchOnlyWords = [
+  "V1147",
+  "V1148",
+  "V1149",
+  "V1150",
+  "V1151",
+  "V1152",
+  "V1154",
+  "V1155",
+  "V1156",
+  "V1157",
+  "V1158",
+  "V1159",
+  "V1160",
+  "V1161",
+  "V1162",
+  "V1163",
+  "V1164",
+  "V1165",
+  "V1168",
+  "V1169",
+  "V1170",
+];

--- a/common/constants/search-only-words.ts
+++ b/common/constants/search-only-words.ts
@@ -1,6 +1,6 @@
 /**
- * Words that should only be found via the search page (not topic view). 
- * The list includes ids of words that are duplicates of topic names 
+ * Words that should only be found via the search page (not topic view).
+ * The list includes ids of words that are duplicates of topic names
  * that doesn't need to be shown in the topic view.
  */
 export const searchOnlyWords = [

--- a/common/utils/data.utils.ts
+++ b/common/utils/data.utils.ts
@@ -1,4 +1,5 @@
 import SuperJSON from "superjson";
+import { searchOnlyWords } from "common/constants/search-only-words";
 import { getAudioFiles } from "common/utils/audio/audio.utils";
 import { getImageUrl } from "common/utils/image/image.utils";
 import { LanguageCode } from "../types/LanguageCode";
@@ -116,7 +117,8 @@ export const getNewWordsFromId = (
 
   return content
     .map(item => idToWords?.get(item))
-    .filter((item): item is NewWord => item !== undefined);
+    .filter((item): item is NewWord => item !== undefined)
+    .filter(item => !searchOnlyWords.includes(item.id));
 };
 
 export const getMainTopics = (

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 119,
+  "patchVersion": 120,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/library.json.d.ts
+++ b/h5p-bildetema-words-grid-view/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "H5P Bildetema Words Grid View";
 export const machineName : "H5P.BildetemaWordsGridView";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 119;
+export const patchVersion : 120;
 export const runnable : 1;
 export const preloadedJs : [
 	{

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 123,
+  "patchVersion": 124,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 252,
+  "patchVersion": 253,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 107,
+  "patchVersion": 108,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json.d.ts
+++ b/h5p-editor-bildetema-words-topic-image/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "Bildetema Words Topic Image Editor";
 export const machineName : "H5PEditor.BildetemaWordsTopicImage";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 107;
+export const patchVersion : 108;
 export const runnable : 0;
 export const preloadedJs : [
 	{


### PR DESCRIPTION
Makes specific words hidden from the topic view. These words can now only be found via the search page (and added to collections from the search page). They will still be visible in collections as before. 