### PR TITLE
fix: force reload of audio

### DIFF
--- a/common/components/Audio/Audio.tsx
+++ b/common/components/Audio/Audio.tsx
@@ -74,10 +74,11 @@ export const Audio: FC<AudioProps> = ({
     >
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
-        {audioFiles?.map(file => (
+        {audioFiles?.map((file, index) => (
           <source
-            key={file.mimeType}
-            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${file.mimeType}-${index}`}
+            src={`${file.url}?v=1`} // Force reload
             type={file.mimeType}
           />
         ))}

--- a/common/components/Audio/Audio.tsx
+++ b/common/components/Audio/Audio.tsx
@@ -75,7 +75,11 @@ export const Audio: FC<AudioProps> = ({
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
         {audioFiles?.map(file => (
-          <source key={file.mimeType} src={file.url} type={file.mimeType} />
+          <source
+            key={file.mimeType}
+            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            type={file.mimeType}
+          />
         ))}
       </audio>
       <button

--- a/h5p-bildetema-words-grid-view/library.json
+++ b/h5p-bildetema-words-grid-view/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaWordsGridView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 122,
+  "patchVersion": 123,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-grid-view/library.json.d.ts
+++ b/h5p-bildetema-words-grid-view/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "H5P Bildetema Words Grid View";
 export const machineName : "H5P.BildetemaWordsGridView";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 122;
+export const patchVersion : 123;
 export const runnable : 1;
 export const preloadedJs : [
 	{

--- a/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.tsx
+++ b/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.tsx
@@ -69,10 +69,11 @@ export const WordAudio: FC<WordAudioProps> = ({
     >
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
-        {word.audioFiles?.map(file => (
+        {word.audioFiles?.map((file, index) => (
           <source
-            key={file.mimeType}
-            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${file.mimeType}-${index}`}
+            src={`${file.url}?v=1`} // Force reload
             type={file.mimeType}
           />
         ))}

--- a/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.tsx
+++ b/h5p-bildetema-words-grid-view/src/components/WordAudio/WordAudio.tsx
@@ -70,7 +70,11 @@ export const WordAudio: FC<WordAudioProps> = ({
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
         {word.audioFiles?.map(file => (
-          <source key={file.mimeType} src={file.url} type={file.mimeType} />
+          <source
+            key={file.mimeType}
+            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            type={file.mimeType}
+          />
         ))}
       </audio>
       <button type="button" onClick={toggleAudio}>

--- a/h5p-bildetema-words-topic-image/library.json
+++ b/h5p-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.BildetemaTopicImageView",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 126,
+  "patchVersion": 127,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageWordAudio/TopicImageWordAudio.tsx
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageWordAudio/TopicImageWordAudio.tsx
@@ -100,10 +100,11 @@ export const TopicImageWordAudio: FC<TopicImageWordAudioProps> = ({
     >
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
-        {word.audioFiles?.map(file => (
+        {word.audioFiles?.map((file, index) => (
           <source
-            key={file.mimeType}
-            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${file.mimeType}-${index}`}
+            src={`${file.url}?v=1`} // Force reload
             type={file.mimeType}
           />
         ))}

--- a/h5p-bildetema-words-topic-image/src/components/TopicImageWordAudio/TopicImageWordAudio.tsx
+++ b/h5p-bildetema-words-topic-image/src/components/TopicImageWordAudio/TopicImageWordAudio.tsx
@@ -101,7 +101,11 @@ export const TopicImageWordAudio: FC<TopicImageWordAudioProps> = ({
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
         {word.audioFiles?.map(file => (
-          <source key={file.mimeType} src={file.url} type={file.mimeType} />
+          <source
+            key={file.mimeType}
+            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            type={file.mimeType}
+          />
         ))}
       </audio>
       <button

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 255,
+  "patchVersion": 256,
   "runnable": 1,
   "preloadedJs": [
     {

--- a/h5p-bildetema/src/components/TopicGridElementAudio/TopicGridElementAudio.tsx
+++ b/h5p-bildetema/src/components/TopicGridElementAudio/TopicGridElementAudio.tsx
@@ -68,7 +68,11 @@ export const TopicGridElementAudio: FC<TopicGridElementAudioProps> = ({
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
         {audioFiles?.map(file => (
-          <source key={file.mimeType} src={file.url} type={file.mimeType} />
+          <source
+            key={file.mimeType}
+            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            type={file.mimeType}
+          />
         ))}
       </audio>
       <button type="button" onClick={toggleAudio}>

--- a/h5p-bildetema/src/components/TopicGridElementAudio/TopicGridElementAudio.tsx
+++ b/h5p-bildetema/src/components/TopicGridElementAudio/TopicGridElementAudio.tsx
@@ -67,10 +67,11 @@ export const TopicGridElementAudio: FC<TopicGridElementAudioProps> = ({
     >
       {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
       <audio ref={audioRef} onEnded={handleAudioEnded}>
-        {audioFiles?.map(file => (
+        {audioFiles?.map((file, index) => (
           <source
-            key={file.mimeType}
-            src={`${file.url}?${new Date().getTime()}`} // Add timestamp to force reload
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${file.mimeType}-${index}`}
+            src={`${file.url}?v=1`} // Force reload
             type={file.mimeType}
           />
         ))}

--- a/h5p-editor-bildetema-words-topic-image/library.json
+++ b/h5p-editor-bildetema-words-topic-image/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5PEditor.BildetemaWordsTopicImage",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 110,
+  "patchVersion": 111,
   "runnable": 0,
   "preloadedJs": [
     {

--- a/h5p-editor-bildetema-words-topic-image/library.json.d.ts
+++ b/h5p-editor-bildetema-words-topic-image/library.json.d.ts
@@ -2,7 +2,7 @@ export const title : "Bildetema Words Topic Image Editor";
 export const machineName : "H5PEditor.BildetemaWordsTopicImage";
 export const majorVersion : 1;
 export const minorVersion : 0;
-export const patchVersion : 110;
+export const patchVersion : 111;
 export const runnable : 0;
 export const preloadedJs : [
 	{


### PR DESCRIPTION
Fixing issue with old versions of audio files still being played in frontend even though new ones are added to Azure. New and old files use the same file name, and we therefore need to force a reload to make sure the browser plays the new audio file. 