### PR TITLE
fix: rmy translations

### DIFF
--- a/h5p-bildetema/language/nb.json
+++ b/h5p-bildetema/language/nb.json
@@ -445,8 +445,8 @@
           "default": "Pashto"
         },
         {
-          "label": "Romanes",
-          "default": "Romanes"
+          "label": "Vlax Romani",
+          "default": "Vlax Romani"
         },
         {
           "label": "Rumensk",
@@ -571,7 +571,7 @@
             "value": "pus"
           },
           {
-            "label": "Romanes",
+            "label": "Vlax Romani",
             "value": "rmy"
           },
           {

--- a/h5p-bildetema/language/nn.json
+++ b/h5p-bildetema/language/nn.json
@@ -445,8 +445,8 @@
           "default": "Pashto"
         },
         {
-          "label": "Romanes",
-          "default": "Romanes"
+          "label": "Vlax Romani",
+          "default": "Vlax Romani"
         },
         {
           "label": "Rumensk",
@@ -571,7 +571,7 @@
             "value": "pus"
           },
           {
-            "label": "Romanes",
+            "label": "Vlax Romani",
             "value": "rmy"
           },
           {

--- a/h5p-bildetema/library.json
+++ b/h5p-bildetema/library.json
@@ -3,7 +3,7 @@
   "machineName": "H5P.Bildetema",
   "majorVersion": 1,
   "minorVersion": 0,
-  "patchVersion": 258,
+  "patchVersion": 259,
   "runnable": 1,
   "preloadedJs": [
     {


### PR DESCRIPTION
Changes "Romanes" to "Vlax Romani" for Norwegian bokmål and nynorsk.